### PR TITLE
Dev20

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Dashing2 is the second version of the Dashing sequence sketching and comparison 
 
 There have been several major changes, but you can still can get a quick start to compare a group of sequence collections [here](#quickstart).
 
+[Installation instructions](#installation) can be found below.
+
 ### New Features
 
 tl;dr --
@@ -140,7 +142,6 @@ by setting opts.cssize\_ > 0.
 
 ProbMinHash is usually significantly (2-20+x) faster than BagMinHash, although multiset jaccard may be more appropriate for some problems.
 For instance, expression and chromatic accessibility might be better considered discrete probability distributions and therefore fit ProbMinHash, whereas genomic sequences better match the multiset concept and benefit from BagMinHash, which is a MinHash algorithm for weighted sets.
-
 
 
 #### QuickStart

--- a/src/bedsketch.cpp
+++ b/src/bedsketch.cpp
@@ -30,7 +30,7 @@ std::pair<std::vector<RegT>, double> bed2sketch(const std::string &path, const D
             retvec.push_back(v);
         }
         ret.second = retvec.size() / std::accumulate(retvec.begin(), retvec.end(), 0.L);
-        std::fclose(ifp);
+        ::pclose(ifp);
         return ret;
     }
     for(std::string s;std::getline(ifs, s);) {

--- a/src/bwsketch.cpp
+++ b/src/bwsketch.cpp
@@ -52,6 +52,7 @@ BigWigSketchResult bw2sketch(std::string path, const Dashing2Options &opts, bool
             std::fread(&v, sizeof(v), 1, ifp);
             res->push_back(v);
         }
+        ::pclose(ifp);
         ret.global_.reset(res);
         return ret;
     }
@@ -154,6 +155,7 @@ BigWigSketchResult bw2sketch(std::string path, const Dashing2Options &opts, bool
         ret.card_ = total_weight;
         ret.global_.reset(new std::vector<RegT>(std::move(reduce(retmap))));
     } else {
+        DBG_ONLY(auto timestart = std::chrono::high_resolution_clock::now();)
         auto cp = fp->cl;
         const int nk = cp->nKeys;
         std::unique_ptr<FullSetSketch> fss;
@@ -196,6 +198,8 @@ BigWigSketchResult bw2sketch(std::string path, const Dashing2Options &opts, bool
             std::fprintf(stderr, "Warning: infinite cardinality\n");
         }
         ret.global_.reset(new std::vector<RegT>(bmh ? bmh->to_sigs(): pmh ? pmh->to_sigs(): opss ? opss->to_sigs(): fss ? fss->to_sigs(): std::vector<RegT>()));
+        DBG_ONLY(auto timestop = std::chrono::high_resolution_clock::now();
+                 std::fprintf(stderr, "Took %gms to sketch\n", std::chrono::duration<double>(timestop - timestart).count());)
     }
 
     bwClose(fp);

--- a/src/bwsketch.h
+++ b/src/bwsketch.h
@@ -5,7 +5,7 @@ namespace dashing2 {
 
 using BigWigSketchResult = IntervalSketchResult;
 
-BigWigSketchResult bw2sketch(std::string path, const Dashing2Options &opts);
+BigWigSketchResult bw2sketch(std::string path, const Dashing2Options &opts, bool);
 std::vector<RegT> reduce(const flat_hash_map<std::string, std::vector<RegT>> &map);
 #ifndef BLOCKS_PER_ITER
 #define BLOCKS_PER_ITER 4000000

--- a/src/cmp_main.cpp
+++ b/src/cmp_main.cpp
@@ -133,7 +133,7 @@ int cmp_main(int argc, char **argv) {
     bool hpcompress = false;
     std::string fsarg;
     Measure measure = SIMILARITY;
-    uint64_t seedseed = 0;
+    uint64_t seedseed = 13;
     size_t batch_size = 16;
     std::string spacing;
     // By default, use full hash values, but allow people to enable smaller

--- a/src/counter.h
+++ b/src/counter.h
@@ -49,11 +49,6 @@ struct Counter {
     }
     void reset();
     bool empty() const;
-#if 0
-    void populate(std::string lhs, std::string rhs, bool is128=false, char ktype='L', char ctype='d') {
-         // TODO: allow this to read these values from disk instead of re-calculating if present
-    }
-#endif
     void add(u128_t x, double inc) {
         switch(ct()) {
             case COUNTSKETCH_COUNTING: case COUNTMIN_COUNTING: {
@@ -116,7 +111,7 @@ struct Counter {
         } else {
             for(size_t i = 0; i < count_sketch_.size(); ++i)
                 if(count_sketch_[i] > threshold)
-                   tmp.push_back({i, count_sketch_[i]});
+                   tmp.push_back({maskfn(uint64_t(i)), count_sketch_[i]});
         }
         // When finalizing, hash the ids so that our hash sets are sorted hash sets
         // which means we can make a minhash sketch by taking the prefix!
@@ -153,7 +148,7 @@ struct Counter {
     }
 };
 
-}
+} // dashing2
 
 #endif
 

--- a/src/d2.cpp
+++ b/src/d2.cpp
@@ -97,17 +97,6 @@ void Dashing2Options::validate() const {
     }
 }
 
-uint64_t XORMASK = 0x724526e320f9967dull;
-u128_t XORMASK2 = (u128_t(12499408336417088522ull) << 64) | XORMASK;
-void seed_mask(uint64_t x) {
-    if(x == 0) {
-        XORMASK = 0; XORMASK2 = 0;
-    } else {
-        wy::WyRand<uint64_t> rng(x);
-        XORMASK = rng();
-        XORMASK2 = (u128_t(rng()) << 64) | XORMASK;
-    }
-}
 bool entmin = false;
 
 } // dashing2

--- a/src/d2.h
+++ b/src/d2.h
@@ -79,7 +79,6 @@ static inline bool check_compressed(std::string &path, int &ft) {
     }
     return false;
 }
-void seed_mask(uint64_t); // This function sets the seeds
 
 struct Dashing2Options {
 
@@ -217,26 +216,6 @@ static INLINE bool endswith(std::string lhs, std::string rhs) {
     return std::equal(rhs.begin(), rhs.end(), &lhs[lhs.size() - rhs.size()]);
 }
 
-
-extern uint64_t XORMASK;
-extern u128_t XORMASK2;
-
-INLINE uint64_t maskfn(uint64_t x) {
-    x ^= XORMASK;
-#if WANGHASH_EXTRA
-    x = sketch::hash::WangHash::hash(x);
-#endif
-    return x;
-}
-INLINE uint64_t invmaskfn(uint64_t x) {
-#if WANGHASH_EXTRA
-    x = sketch::hash::WangHash::inverse(x);
-#endif
-    x ^= XORMASK;
-    return x;
-}
-INLINE u128_t maskfn(u128_t x) {return x ^ XORMASK2;}
-INLINE u128_t invmaskfn(u128_t x) {return x ^ XORMASK2;}
 
 using KmerSigT = std::conditional_t<(sizeof(RegT) == 8), uint64_t, std::conditional_t<(sizeof(RegT) == 4), uint32_t, u128_t>>;
 using FullSetSketch = sketch::setsketch::CountFilteredCSetSketch<RegT>;

--- a/src/d2.h
+++ b/src/d2.h
@@ -193,7 +193,7 @@ public:
     }
     void filterset(std::string path, bool is_kmer);
     void filterset(std::string fsarg);
-    CountingType ct() const {return cssize_ > 0 ? COUNTSKETCH_COUNTING: EXACT_COUNTING;}
+    CountingType ct() const {return cssize_ > 0 ? COUNTMIN_COUNTING: EXACT_COUNTING;}
     CountingType count() const {return ct();}
     bool trim_folder_paths() const {
         return trim_folder_paths_ || outprefix_.size();
@@ -228,7 +228,15 @@ INLINE uint64_t maskfn(uint64_t x) {
 #endif
     return x;
 }
+INLINE uint64_t invmaskfn(uint64_t x) {
+#if WANGHASH_EXTRA
+    x = sketch::hash::WangHash::inverse(x);
+#endif
+    x ^= XORMASK;
+    return x;
+}
 INLINE u128_t maskfn(u128_t x) {return x ^ XORMASK2;}
+INLINE u128_t invmaskfn(u128_t x) {return x ^ XORMASK2;}
 
 using KmerSigT = std::conditional_t<(sizeof(RegT) == 8), uint64_t, std::conditional_t<(sizeof(RegT) == 4), uint32_t, u128_t>>;
 using FullSetSketch = sketch::setsketch::CountFilteredCSetSketch<RegT>;

--- a/src/enums.cpp
+++ b/src/enums.cpp
@@ -88,4 +88,15 @@ std::FILE *xopen(const std::string &path) {
     return fp;
 }
 
+uint64_t XORMASK = 0x724526e320f9967dull;
+u128_t XORMASK2 = (u128_t(12499408336417088522ull) << 64) | XORMASK;
+void seed_mask(uint64_t x) {
+    if(x == 0) {
+        XORMASK = 0; XORMASK2 = 0;
+    } else {
+        XORMASK = sketch::hash::WangHash::hash(x);
+        XORMASK2 = (XORMASK | (u128_t(sketch::hash::WangHash::hash(XORMASK)) << 64));
+    }
+}
+
 }

--- a/src/enums.h
+++ b/src/enums.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <string>
 #include "sketch/macros.h"
+#if WANGHASH_EXTRA
+#include "sketch/hash.h"
+#endif
 
 namespace dashing2 {
 
@@ -114,7 +117,7 @@ INLINE uint64_t maskfn(uint64_t x) {
 }
 INLINE uint64_t invmaskfn(uint64_t x) {
 #if WANGHASH_EXTRA
-    x = sketch::hash::WangHash::inverse(x);
+    x = sketch::hash::WangHash().inverse(x);
 #endif
     x ^= XORMASK;
     return x;

--- a/src/enums.h
+++ b/src/enums.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include "sketch/macros.h"
 
 namespace dashing2 {
 
@@ -100,5 +101,27 @@ struct Dashing2Options;
 std::string to_suffix(const Dashing2Options &opts);
 void checked_fwrite(std::FILE *fp, const void *src, const size_t nb);
 std::FILE *xopen(const std::string &path);
+
+extern uint64_t XORMASK;
+extern u128_t XORMASK2;
+
+INLINE uint64_t maskfn(uint64_t x) {
+    x ^= XORMASK;
+#if WANGHASH_EXTRA
+    x = sketch::hash::WangHash::hash(x);
+#endif
+    return x;
+}
+INLINE uint64_t invmaskfn(uint64_t x) {
+#if WANGHASH_EXTRA
+    x = sketch::hash::WangHash::inverse(x);
+#endif
+    x ^= XORMASK;
+    return x;
+}
+INLINE u128_t maskfn(u128_t x) {return x ^ XORMASK2;}
+INLINE u128_t invmaskfn(u128_t x) {return x ^ XORMASK2;}
+void seed_mask(uint64_t); // This function sets the seeds
+
 
 }

--- a/src/options.h
+++ b/src/options.h
@@ -230,6 +230,10 @@ static constexpr const char *siglen =
         "--protein8: Use 8 character (3-bit) amino acid alphabet.\n"\
         "--no-canon: If DNA is being encoded, this disables canonicalization. By default, DNA sequence is canonicalized with its reverse-complement.\n"\
         "            Otherwise, this is ignored\n"\
+        "--seed: Set a seed for k-mer hashing; If 0, this disables k-mer XORing and k-mers are encoded directly if a k-mer type can represent it.\n"\
+        "        Otherwise, this changes the hash function applied to k-mers when generated sorted hash sets. This makes it easy to decode quickly, but we can still get good bottom-k estimates using these hashes\n"\
+        "        the xor value for u64 kmers (unless --long-kmers is enabled) is the Wang 64-bit hash of the seed.\n"\
+        "        u128 kmers (--long-kmers) have the same lower 64 bits, but the upper 64 bits are the Wang 64-bit hash of the u64 xor value.\n"\
         "\nPathsOptions\n\n"\
         "By default, dashing2 reads positional arguments and sketches them. You may want to use flags instructing it\n"\
         "to read from paths in <file>. Additionally, you can put multiple files separated by spaces into a single line "\

--- a/src/sketch_core.cpp
+++ b/src/sketch_core.cpp
@@ -36,11 +36,11 @@ SketchingResult sketch_core(Dashing2Options &opts, const std::vector<std::string
             }
         } else {
             // BigWig sketching is parallelized within files
-            if(npaths == 1) {
+            if(npaths == 1 || opts.by_chrom_) {
                 auto res = bw2sketch(paths.front(), opts, /*parallel_process=*/true);
                 auto sigs = std::move(*res.global_.get());
                 result.cardinalities_.front() = res.card_;
-                std::copy(sigs.begin(), sigs.end(), &result.signatures_.begin());
+                std::copy(sigs.begin(), sigs.end(), result.signatures_.data());
             } else {
                 OMP_PFOR_DYN
                 for(size_t i = 0; i < npaths; ++i) {

--- a/src/sketch_main.cpp
+++ b/src/sketch_main.cpp
@@ -44,7 +44,7 @@ int sketch_main(int argc, char **argv) {
     double nbytes_for_fastdists = sizeof(RegT);
     bool parse_by_seq = false;
     double downsample_frac = 1.;
-    uint64_t seedseed = 0;
+    uint64_t seedseed = 13;
     size_t batch_size = 16;
     int nLSH = 2;
     Measure measure = SIMILARITY;


### PR DESCRIPTION
1. Addition of --seed parameter to change the hash function.
    1. We default to 13, but if this is set to 0, k-mers are stored exactly.
    2. Otherwise, the k-mer sets are sorted hashes and a prefix of them is a bottom-k minhash sketch. 
2. Speed improvements for BigWig processing.
3. Use the same cache path for the k-mers for FullMmerSet and FullMmerCountDict, so that if `--cached --countdict` has been called, `--cached --set` will use the existing k-mer set.
4. Add support for xz-, bzip2-, and zstd- compressed files.
5. Use weighted bottom-k sketches when shingling exactly via `--countdict`.
    1. See [Summarizing Data with Bottom-k Sketches](https://dl.acm.org/doi/10.1145/1281100.1281133).
    2. This only affects the LSH table constructed when doing thresholded, top-k, or HIT clustering modes.