### PR TITLE
Breaking changes: default output mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,12 @@
 
 CXX?=g++
 
+CACHE_SIZE?=4194304
+CACHE_SIZE_FLAG:=-DD2_CACHE_SIZE=${CACHE_SIZE}
+
 LIB=-lz
 INC=-IlibBigWig -Ibonsai/include -Ibonsai -Ibonsai/hll -Ibonsai/hll/include -Ibonsai -I. -Isrc
-OPT+= -O3 -march=native -fopenmp -pipe
+OPT+= -O3 -march=native -fopenmp -pipe $(CACHE_SIZE_FLAG)
 OPTMV:=$(OPT)
 OPT+= -std=c++17
 WARNING+=-Wall -Wextra -Wno-unused-function -Wno-char-subscripts -pedantic # -Wno-shift-count-overflow
@@ -37,7 +40,6 @@ SEDSTR=
 ifeq ($(shell uname -s ),Darwin)
     SEDSTR = " '' "
 endif
-
 
 OBJFS=src/enums.cpp src/counter.cpp src/fastxsketch.cpp src/merge.cpp src/bwsketch.cpp src/bedsketch.cpp src/fastxsketchbyseq.cpp src/bwreduce.cpp
 LIBOBJ=$(patsubst %.cpp,%.o,$(OBJFS))

--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ This is for the case where there are a set of integral identifiers for sketching
 See `dashing2 wsketch --help` for usage and examples.
 
 
-
 ### Installation
 
 Easiest installation is `git clone --recursive https://github.com/dnbaker/dashing2 && make -j4`.
@@ -246,9 +245,23 @@ Easiest installation is `git clone --recursive https://github.com/dnbaker/dashin
 Dashing2 is written in C++17, and therefore needs a relatively recent compiler.
 
 
-## Versions
+## Versions + Configuration
 
-To process more than `std::numeric_limits<uint32_t>::max()` = 0xFFFFFFFF IDs in a table, you must use `dashing2-64`, which uses 64-bit identifiers.
+1. More than 2^32 items -
+`dashing2` uses 32-bit hash identifiers in LSH tables for speed and memory efficiency.
+To use more than 4.3 billion, use `dashing2-64`, which switched to 64-bit identifiers and hashes.
 
 The default version of Dashing2 is dashing2, which uses 32-bit LSH keys and ID types in its NN tables;
 this is faster and more memory-efficient, but less specific;
+
+2. Hardware cache size
+When comparing sketches, computations are grouped for better cache efficiency.
+A group size is selected to fit as many sketches as possible in cache;
+The default cache size estimate is 4MB. To change this, set the `D2_CACHE_SIZE` environment variable.
+
+```sh
+# set cache size to 64 MB
+export D2_CACHE_SIZE=67108864
+```
+
+As an aside, these sketches are stored contiguously to reduce fragmentation compared to Dashing1.

--- a/src/bwsketch.cpp
+++ b/src/bwsketch.cpp
@@ -34,7 +34,6 @@ BigWigSketchResult bw2sketch(std::string path, const Dashing2Options &opts, bool
         cache_path += ".seed" + std::to_string(opts.seedseed_);
     if(opts.kmer_result_ <= FULL_SETSKETCH)
         cache_path = cache_path + std::string(".sketchsize") + std::to_string(opts.sketchsize_);
-    cache_path = cache_path + std::string(".k") + std::to_string(opts.k_);
     if(opts.count_threshold_ > 0) {
         cache_path = cache_path + ".ct_threshold";
         if(std::fmod(opts.count_threshold_, 1.)) cache_path = cache_path + std::to_string(opts.count_threshold_);

--- a/src/cmp_core.cpp
+++ b/src/cmp_core.cpp
@@ -97,7 +97,7 @@ make_compressed(int truncation_method, double fd, const std::vector<RegT> &sigs,
             maxreg = std::max(maxreg, v);
         }
         std::fprintf(stderr, "Tailoring setsketch parameters with min/max register values, fd = %g: %Lg->%Lg\n", fd, static_cast<long double>(minreg), static_cast<long double>(maxreg));
-        long double q = fd == 1. ? 254.3: fd == 2. ? 65534.3: fd == 4. ? 4294967294.3: fd == 8. ? 18446744073709551615. : fd == 0.5 ? 15.4: -1.;
+        long double q = fd == 1. ? 254.3: fd == 2. ? 65534: fd == 4. ? 4294967294: fd == 8. ? 18446744073709551615. : fd == 0.5 ? 15.4: -1.;
         long double logbinv;
         assert(q > 0.);
         auto [b, a] = sketch::CSetSketch<RegT>::optimal_parameters(minreg, maxreg, q);
@@ -127,7 +127,6 @@ make_compressed(int truncation_method, double fd, const std::vector<RegT> &sigs,
                 } else {
                     const int64_t isub = std::max(int64_t(0), std::min(int64_t(q + 1), static_cast<int64_t>(sub)));
                     //if(sub < 0.) std::fprintf(stderr, "Mapping %g to %zd with sub = %Lg\n", double(sigs[i]), isub, sub);
-                    //std::fprintf(stderr, "Mapping %g to %d\n", double(sigs[i]), isub);
                     if(fd == 4)      ((uint32_t *)compressed_reps)[i] = isub;
                     else if(fd == 2) ((uint16_t *)compressed_reps)[i] = isub;
                     else             ((uint8_t *)compressed_reps)[i] = isub;
@@ -203,7 +202,8 @@ case v: {TYPE *ptr = static_cast<TYPE *>(opts.compressed_ptr_); equal_regs = ske
 #define CASE_ENTRY(v, TYPE)\
 case v: {\
     TYPE *ptr = static_cast<TYPE *>(opts.compressed_ptr_);\
-    res = sketch::eq::count_gtlt(ptr + i * opts.sketchsize_, ptr + j * opts.sketchsize_, opts.sketchsize_);} break;
+    res = sketch::eq::count_gtlt(ptr + i * opts.sketchsize_, ptr + j * opts.sketchsize_, opts.sketchsize_);\
+    } break;
                 CASEPOW2
 #undef CASE_ENTRY
 #undef CASEPOW2
@@ -239,6 +239,7 @@ case v: {\
                 alpha = g_b(b, alpha);
                 beta = g_b(b, beta);
             }
+            VERBOSE_ONLY(std::fprintf(stderr, "Alpha: %Lg. Beta: %Lg\n", alpha, beta);)
             if(alpha + beta >= 1.) {
                 mu = lhcard + rhcard;
             } else {

--- a/src/cmp_core.cpp
+++ b/src/cmp_core.cpp
@@ -414,7 +414,7 @@ void cmp_core(const Dashing2DistOptions &opts, SketchingResult &result) {
             auto lp = &result.signatures_[opts.sketchsize_ * i];
             totaldens += densify(lp, kp ? &kp[opts.sketchsize_ * i]: kp, opts.sketchsize_, sd);
         }
-        std::fprintf(stderr, "Densified a total of %zu/%zu entries\n", totaldens, opts.sketchsize_ * n);
+        if(totaldens > 0) std::fprintf(stderr, "Densified a total of %zu/%zu entries\n", totaldens, opts.sketchsize_ * n);
     }
     //std::fprintf(stderr, "Handled generating needed cardinalities\n");
     // Calculate cardinalities if they haven't been

--- a/src/cmp_core.cpp
+++ b/src/cmp_core.cpp
@@ -35,10 +35,10 @@ static INLINE uint64_t reg2sig(RegT x) {
 #endif
 
 std::string path2cmd(const std::string &path) {
-    if(std::equal(path.rbegin(), path.rbegin() + 3, "zg.")) return std::string("gzip -dc ") + path;
-    if(std::equal(path.rbegin(), path.rbegin() + 3, "zx.")) return std::string("xz -dc ") + path;
-    if(std::equal(path.rbegin(), path.rbegin() + 4, "2zb.")) return std::string("bzip2 -dc ") + path;
-    return std::string("cat ") + path;
+    if(std::equal(path.rbegin(), path.rbegin() + 3, "zg.")) return "gzip -dc "s + path;
+    if(std::equal(path.rbegin(), path.rbegin() + 3, "zx.")) return "xz -dc "s + path;
+    if(std::equal(path.rbegin(), path.rbegin() + 4, "2zb.")) return "bzip2 -dc "s + path;
+    return "cat "s + path;
 }
 
 struct CompressedRet: public std::tuple<void *, long double, long double> {
@@ -308,13 +308,13 @@ case v: {\
         if(lpath.empty() || rpath.empty()) THROW_EXCEPTION(std::runtime_error("Destination files for k-mers empty -- cannot load from disk"));
         std::FILE *lhk = 0, *rhk = 0, *lhn = 0, *rhn = 0;
         std::string lcmd = path2cmd(lpath), rcmd = path2cmd(rpath);
-        if((lhk = ::popen(lcmd.data(), "r")) == nullptr) THROW_EXCEPTION(std::runtime_error(std::string("Failed to run lcmd '") + lcmd + "'"));
-        if((rhk = ::popen(rcmd.data(), "r")) == nullptr) THROW_EXCEPTION(std::runtime_error(std::string("Failed to run rcmd '") + rcmd + "'"));
+        if((lhk = ::popen(lcmd.data(), "r")) == nullptr) THROW_EXCEPTION(std::runtime_error("Failed to run lcmd '"s + lcmd + "'"));
+        if((rhk = ::popen(rcmd.data(), "r")) == nullptr) THROW_EXCEPTION(std::runtime_error("Failed to run rcmd '"s + rcmd + "'"));
         if(result.kmercountfiles_.size()) {
             lcmd = path2cmd(result.kmercountfiles_[i]);
             rcmd = path2cmd(result.kmercountfiles_[j]);
-            if((lhn = ::popen(lcmd.data(), "r")) == nullptr) THROW_EXCEPTION(std::runtime_error(std::string("Failed to run lcmd '") + lcmd + "'"));
-            if((rhn = ::popen(rcmd.data(), "r")) == nullptr) THROW_EXCEPTION(std::runtime_error(std::string("Failed to run lcmd '") + rcmd + "'"));
+            if((lhn = ::popen(lcmd.data(), "r")) == nullptr) THROW_EXCEPTION(std::runtime_error("Failed to run lcmd '"s + lcmd + "'"));
+            if((rhn = ::popen(rcmd.data(), "r")) == nullptr) THROW_EXCEPTION(std::runtime_error("Failed to run lcmd '"s + rcmd + "'"));
         }
         if(opts.kmer_result_ == FULL_MMER_SEQUENCE) {
             if(opts.exact_kmer_dist_) {
@@ -390,11 +390,11 @@ void cmp_core(const Dashing2DistOptions &opts, SketchingResult &result) {
                 if(endswith(result.kmercountfiles_[i], ".xz")) ft = 2;
                 else if(endswith(result.kmercountfiles_[i], ".gz")) ft = 1;
                 else ft = 0;
-                std::string cmd = std::string(ft == 0 ? "cat ": ft == 1 ? "gzip -dc ": ft == 2 ? "xz -dc " : "unknowncommand");
+                std::string cmd = ft == 0 ? "cat "s: ft == 1 ? "gzip -dc "s: ft == 2 ? "xz -dc "s : "unknowncommand"s;
                 if(cmd == "unknowncommand") THROW_EXCEPTION(std::runtime_error("Failure"));
                 cmd += result.kmercountfiles_[i];
                 if(!(ifp = ::popen(cmd.data(), "r")))
-                    THROW_EXCEPTION(std::runtime_error(std::string("Command ") + "'" + cmd + "' failed."));
+                    THROW_EXCEPTION(std::runtime_error("Command '"s + cmd + "' failed."));
                 double x, c, s;
                 for(x = c = s = 0.;std::fread(&x, sizeof(x), 1, ifp) == 1u;sketch::kahan::update(s, c, x));
                 result.cardinalities_[i] = s;

--- a/src/cmp_main.cpp
+++ b/src/cmp_main.cpp
@@ -181,7 +181,7 @@ int cmp_main(int argc, char **argv) {
     std::unique_ptr<std::vector<std::string>> qup;
     std::string cmd(std::filesystem::absolute(std::filesystem::path(argv[-1])));
     for(char **s = argv; *s; cmd += std::string(" ") + *s++);
-    std::fprintf(stderr, "[Dashing2] Invocation: %s ", cmd.data());
+    std::fprintf(stderr, "#Invocation: %s\n", cmd.data());
     if(nt < 0) {
         char *s = std::getenv("OMP_NUM_THREADS");
         if(s) nt = std::max(std::atoi(s), 1);

--- a/src/cmp_main.cpp
+++ b/src/cmp_main.cpp
@@ -176,14 +176,7 @@ int cmp_main(int argc, char **argv) {
         SHARED_FIELDS
         case OPTARG_HELP: case '?': case 'h': cmp_usage(); return 1;
     }}
-    if(k < 0) {
-        if(rht == bns::DNA) k = 31;
-        else if(rht == bns::DNA2) k = 63;
-        else if(rht == bns::PROTEIN20) k = 14;
-        else if(rht == bns::PROTEIN_14) k = 16;
-        else if(rht == bns::PROTEIN_3BIT) k = 22;
-        else if(rht == bns::PROTEIN_6) k = 24;
-    }
+    if(k < 0) k = nregperitem(rht, use128);
     std::vector<std::string> paths(argv + optind, argv + argc);
     std::unique_ptr<std::vector<std::string>> qup;
     std::string cmd(std::filesystem::absolute(std::filesystem::path(argv[-1])));

--- a/src/cmp_main.h
+++ b/src/cmp_main.h
@@ -100,6 +100,8 @@ struct Dashing2DistOptions: public Dashing2Options {
 void cmp_core(const Dashing2DistOptions &ddo, SketchingResult &res);
 LSHDistType compare(const Dashing2DistOptions &opts, const SketchingResult &result, size_t i, size_t j);
 void emit_rectangular(const Dashing2DistOptions &opts, const SketchingResult &result);
+size_t default_batchsize(size_t &batch_size, const Dashing2DistOptions &opts);
+
 
 }
 

--- a/src/counter.h
+++ b/src/counter.h
@@ -30,7 +30,7 @@ struct Counter {
     flat_hash_map<u128_t, int32_t, FHasher> c128_;
     flat_hash_map<uint64_t, double> c64d_;
     flat_hash_map<u128_t, double, FHasher> c128d_;
-    std::vector<double> count_sketch_;
+    std::vector<float> count_sketch_;
     schism::Schismatic<uint64_t> s64_;
     CountingType ct() const {return count_sketch_.size() ? COUNTSKETCH_COUNTING: EXACT_COUNTING;}
     Counter(size_t cssize=0): count_sketch_(cssize), s64_(cssize + !cssize) {}
@@ -109,9 +109,16 @@ struct Counter {
             };
             update_if(c64_) || update_if(c128_) || update_if(c64d_) || update_if(c128d_) || std::fprintf(stderr, "Note: finalizing empty structure\n");
         } else {
-            for(size_t i = 0; i < count_sketch_.size(); ++i)
-                if(count_sketch_[i] > threshold)
-                   tmp.push_back({maskfn(uint64_t(i)), count_sketch_[i]});
+            const auto csp = count_sketch_.data();
+            const auto cssz = count_sketch_.size();
+#ifdef _OPENMP
+            #pragma omp simd
+#endif
+            for(size_t i = 0; i < cssz; ++i) {
+                if(auto v = std::abs(count_sketch_[i]); v > threshold) {
+                   tmp.push_back({maskfn(uint64_t(i)), v});
+                }
+            }
         }
         // When finalizing, hash the ids so that our hash sets are sorted hash sets
         // which means we can make a minhash sketch by taking the prefix!

--- a/src/counter.h
+++ b/src/counter.h
@@ -115,7 +115,7 @@ struct Counter {
             #pragma omp simd
 #endif
             for(size_t i = 0; i < cssz; ++i) {
-                if(auto v = std::abs(count_sketch_[i]); v > threshold) {
+                if(auto v = std::abs(csp[i]); v > threshold) {
                    tmp.push_back({maskfn(uint64_t(i)), v});
                 }
             }

--- a/src/d2.h
+++ b/src/d2.h
@@ -127,11 +127,13 @@ public:
     Dashing2Options(int k, int w=-1, bns::RollingHashingType rht=bns::DNA, SketchSpace space=SPACE_SET, DataType dtype=FASTX, size_t nt=0, bool use128=false, std::string spacing="", bool canon=false, KmerSketchResultType kres=ONE_PERM):
         k_(k), w_(w), sp_(k, w > 0 ? w: k, spacing.data()), enc_(sp_, canon), rh_(k, canon, rht, w), rh128_(k, canon, rht, w), rht_(rht), spacing_(spacing), sspace_(space), dtype_(dtype), use128_(use128) {
         kmer_result_ = kres;
+#ifndef NDEBUG
         if(dtype_ == FASTX) {
             std::fprintf(stderr, "Dashing2 made with k = %d, w = %d, %s target, space = %s, datatype = %s and result = %s\n", k, w, rht == bns::DNA ? "DNA": "Protein", ::dashing2::to_string(sspace_).data(), ::dashing2::to_string(dtype_).data(), ::dashing2::to_string(kmer_result_).data());
         } else {
             std::fprintf(stderr, "Dashing2 made with space = %s, datatype = %s and result = %s\n", ::dashing2::to_string(sspace_).data(), ::dashing2::to_string(dtype_).data(), ::dashing2::to_string(kmer_result_).data());
         }
+#endif
         if(nt <= 0) {
             DBG_ONLY(std::fprintf(stderr, "[%s:%s:%d] num threads < 0, checking OMP_NUM_THREADS\n", __FILE__, __func__, __LINE__);)
             if(char *s = std::getenv("OMP_NUM_THREADS"))

--- a/src/d2.h
+++ b/src/d2.h
@@ -225,6 +225,22 @@ using BagMinHash = sketch::BagMinHash2<RegT>;
 using ProbMinHash = sketch::pmh2_t<RegT>;
 using OrderMinHash = sketch::omh::OMHasher<RegT>;
 
+static constexpr size_t nregperitem(bns::RollingHashingType it, bool is128=false) {
+    using namespace bns;
+    switch(it) {
+        case DNA: return is128 ? RHTraits<DNA>::nper128: RHTraits<DNA>::nper64;
+        case PROTEIN: return is128 ? RHTraits<PROTEIN>::nper128: RHTraits<PROTEIN>::nper64;
+        case PROTEIN20: return is128 ? RHTraits<PROTEIN20>::nper128: RHTraits<PROTEIN20>::nper64;
+        case PROTEIN_3BIT: return is128 ? RHTraits<PROTEIN_3BIT>::nper128: RHTraits<PROTEIN_3BIT>::nper64;
+        case PROTEIN_14: return is128 ? RHTraits<PROTEIN_14>::nper128: RHTraits<PROTEIN_14>::nper64;
+        case PROTEIN_6: return is128 ? RHTraits<PROTEIN_6>::nper128: RHTraits<PROTEIN_6>::nper64;
+        case DNAC: return is128 ? RHTraits<DNAC>::nper128: RHTraits<DNAC>::nper64;
+        case PROTEIN_6_FRAME: return is128 ? RHTraits<PROTEIN_6_FRAME>::nper128: RHTraits<PROTEIN_6_FRAME>::nper64;
+        default: ;
+    }
+    return 0; // Should not ever happen
+}
+
 extern bool entmin;
 
 } // namespace dashing2

--- a/src/d2.h
+++ b/src/d2.h
@@ -16,6 +16,7 @@
 
 
 namespace dashing2 {
+using namespace std::literals::string_literals;
 using namespace sketch;
 
 // To allow for 64-bit set identifiers, compile with -DLSHIDTYPE=uint64_t

--- a/src/emitrect.cpp
+++ b/src/emitrect.cpp
@@ -111,7 +111,7 @@ void emit_rectangular(const Dashing2DistOptions &opts, const SketchingResult &re
             datq.pop_front();
         }
     });
-    const size_t batch_size = std::max(opts.cmp_batch_size_, size_t(1));
+    const size_t batch_size = std::max(std::min(unsigned(opts.cmp_batch_size_), opts.nthreads()), 1u);
     // We have two access patterns --
     // Unbatched (batch_size <= 1), which fills in the matrix one row at a time
     // and

--- a/src/emitrect.cpp
+++ b/src/emitrect.cpp
@@ -1,6 +1,7 @@
 #include "cmp_main.h"
 
 namespace dashing2 {
+using namespace std::literals::string_literals;
 
 struct QTup: public std::tuple<std::unique_ptr<float[]>, size_t, size_t, size_t> {
     using super = std::tuple<std::unique_ptr<float[]>, size_t, size_t, size_t>;
@@ -17,6 +18,29 @@ struct QTup: public std::tuple<std::unique_ptr<float[]>, size_t, size_t, size_t>
     auto &nwritten() {return std::get<3>(*this);}
     const auto nwritten() const {return std::get<3>(*this);}
 };
+
+template<size_t L>
+constexpr std::array<char, 2 * L + 1> make_tablut() {
+    std::array<char, 2 * L + 1> ret{0};
+    for(size_t i = 0; i < L; ++i) {
+        size_t id = i * 2;
+        ret[id] = '\t';
+        ret[id + 1] = '-';
+    }
+    ret[2 * L] = '\0';
+    return ret;
+}
+
+int print_tabs(size_t n, std::FILE *ofp) {
+    static constexpr std::array<char, 513> arr = make_tablut<256>();
+    static constexpr const char *ts = arr.data();
+    while(n > 256) {
+        if(std::fwrite(ts, 512, 1, ofp) != 1u) return -1;
+        n -= 256;
+    }
+    const auto nw = 2u * n;
+    return std::fwrite(ts, 1, nw, ofp) == nw ? 0: -2;
+}
 
 void emit_rectangular(const Dashing2DistOptions &opts, const SketchingResult &result) {
     const size_t ns = result.names_.size();
@@ -36,14 +60,18 @@ void emit_rectangular(const Dashing2DistOptions &opts, const SketchingResult &re
 #endif
     // Emit Header
     if(opts.output_format_ == HUMAN_READABLE) {
-        std::fprintf(ofp, "#Dashing2 %s Output\n", asym ? "Asymmetric pairwise": "PHYLIP pairwise");
-        std::fprintf(ofp, "#Dashing2Options: %s\n", opts.to_string().data());
-        std::fprintf(ofp, "#Sources");
-        for(size_t i = 0; i < result.names_.size(); ++i) {
-            std::fprintf(ofp, "\t%s", result.names_[i].data());
+        if(opts.output_kind_ != PHYLIP) {
+            std::fprintf(ofp, "#Dashing2 %s Output\n", asym ? "Asymmetric pairwise": "PHYLIP pairwise");
+            std::fprintf(ofp, "#Dashing2Options: %s\n", opts.to_string().data());
+            std::fprintf(ofp, "#Sources");
+            for(size_t i = 0; i < result.names_.size(); ++i) {
+                std::fputc('\t', ofp);
+                std::fwrite(result.names_[i].data(), 1, result.names_[i].size(), ofp);
+            }
+            std::fputc('\n', ofp);
+        } else {
+            std::fprintf(ofp, "%zu\n", ns);
         }
-        std::fputc('\n', ofp);
-        if(opts.output_kind_ == SYMMETRIC_ALL_PAIRS) std::fprintf(ofp, "%zu\n", ns);
     }
     /*
      *  This is a worker thread which processes and emits
@@ -67,6 +95,9 @@ void emit_rectangular(const Dashing2DistOptions &opts, const SketchingResult &re
                     if(fn.size() < 9) fn.append(9 - fn.size(), ' ');
                     std::fwrite(fn.data(), 1, fn.size(), ofp);
                     const size_t jend = opts.output_kind_ == PANEL ? nq: asym ? ns: ns - i - 1;
+                    if(opts.output_kind_ == SYMMETRIC_ALL_PAIRS && print_tabs(i + 1, ofp) < 0) {
+                        THROW_EXCEPTION(std::runtime_error("Failed to write tabs to for rows starting with "s + std::to_string(datq.front().start())));
+                    }
                     for(size_t j = 0; j < jend; ++j)
                         std::fprintf(ofp, "\t%0.9g", *datp++);
                     std::fputc('\n', ofp);

--- a/src/enums.h
+++ b/src/enums.h
@@ -79,6 +79,7 @@ enum KmerSketchResultType {
 
 enum OutputKind {
     SYMMETRIC_ALL_PAIRS,
+    PHYLIP,
     ASYMMETRIC_ALL_PAIRS,
     KNN_GRAPH, // Fixed top-k neighbors
     NN_GRAPH_THRESHOLD, // Variable number of similarities, as given by threshold

--- a/src/fastxmerge.cpp
+++ b/src/fastxmerge.cpp
@@ -106,10 +106,7 @@ std::string makedest(Dashing2Options &opts, const std::string &path, bool iskmer
     else {
         auto ks = opts.kmer_result_;
         if(iskmer && ks == FULL_MMER_COUNTDICT) {
-            std::fprintf(stderr, "Using MMerSet for the cached path\n");
             ks = FULL_MMER_SET;
-        } else {
-            std::fprintf(stderr, "Using %s\n", to_string(ks).data());
         }
         ret += to_string(ks);
     }

--- a/src/fastxsketch.cpp
+++ b/src/fastxsketch.cpp
@@ -234,9 +234,6 @@ FastxSketchingResult fastx2sketch(Dashing2Options &opts, const std::vector<std::
         if(opts.sspace_ == SPACE_EDIT_DISTANCE) {
             THROW_EXCEPTION(std::runtime_error("edit distance is only available in parse by seq mode"));
         }
-        if(opts.sspace_ == SPACE_MULTISET || opts.sspace_ == SPACE_PSET) {
-             opts.save_kmercounts_ = true; // Always save counts for PMinHash and BagMinHash
-        }
         ret.destination_files_.resize(paths.size());
         if(opts.save_kmers_) {
             ret.kmerfiles_.resize(paths.size());

--- a/src/fastxsketch.cpp
+++ b/src/fastxsketch.cpp
@@ -83,7 +83,6 @@ size_t load_copy(const std::string &path, T *ptr, double *cardinality) {
         for(;!std::feof(fp) && std::fread(up, sizeof(T), chunk_size, fp) == chunk_size; up += chunk_size * sizeof(T));
         sz = (up - (uint8_t *)ptr) / sizeof(T);
     }
-    DBG_ONLY(std::fprintf(stderr, "Loading sketch of size %zu from %s\n", size_t(st.st_size), path.data());)
     std::fclose(fp);
     return sz;
 }

--- a/src/options.h
+++ b/src/options.h
@@ -107,6 +107,7 @@ enum OptArg {
     {"edit-distance", no_argument, 0, 'E'},\
     {"oneperm-setsketch", no_argument, 0, 'Z'},\
     {"oneperm", no_argument, 0, 'Z'},\
+    {"one-perm", no_argument, 0, 'Z'},\
     {"oph", no_argument, 0, 'Z'},\
     {"doph", no_argument, 0, 'Z'},\
     {"normalize-intervals", no_argument, 0, OPTARG_BED_NORMALIZE},\

--- a/src/options.h
+++ b/src/options.h
@@ -97,6 +97,7 @@ enum OptArg {
     LO_FLAG("128bit", '2', use128, true)\
     LO_FLAG("long-kmers", '2', use128, true)\
     LO_FLAG("asymmetric-all-pairs", OPTARG_ASYMMETRIC_ALLPAIRS, ok, OutputKind::ASYMMETRIC_ALL_PAIRS)\
+    LO_FLAG("phylip", OPTARG_PHYLIP, ok, OutputKind::PHYLIP)\
     LO_ARG("regbytes", OPTARG_REGBYTES)\
     /*LO_ARG("set", 'H')*/\
     {"save-kmers", no_argument, 0, 's'},\
@@ -131,7 +132,7 @@ enum OptArg {
     {"nLSH", required_argument, 0, OPTARG_NLSH},\
     {"entmin", no_argument, 0, OPTARG_ENTROPYMIN},\
     {"by-chrom", no_argument, (int *)&by_chrom, 1},\
-    {"sketch-size-l2", required_argument, 0, 'L'}
+    {"sketch-size-l2", required_argument, 0, 'L'},
 
 
 
@@ -209,7 +210,7 @@ enum OptArg {
             }\
             std::fprintf(stderr, "Using log_2 sketchsize = %d, yielding sketchsize = %zu\n", ssl2, sketchsize);\
             break;\
-        }
+        }\
 
 
 
@@ -320,12 +321,13 @@ static constexpr const char *siglen =
         "              This makes the sequences insensitive to the lengths of minimizer stretches, which may simplify match finding\n"\
         "\n\nDistance Options (shared)\n"\
         "--Exhaustive Distance Outputs--\n"\
-        "The default output format is all-pairs PHYLIP upper-triangular.\n"\
-        "We provide two other full matrix methods - \n"\
-        "1. Square distance matrix, enabled by --asymmetric-all-pairs\n"\
+        "The default output format is all-pairs upper-triangular.\n"\
+        "We provide three other full matrix methods - \n"\
+        "1. PHYLIP Upper Triangular distance matrix, enabled by --phylip.\n"\
+        "2. Square distance matrix, enabled by --asymmetric-all-pairs\n"\
         "--asymmetric-all-pairs: emit square distance matrix\n"\
         "Emits a full square distance matrix rather than upper-triangular.\n"\
-        "2. Rectangular matrix, enabled by -Q/-qfile\n"\
+        "3. Rectangular matrix, enabled by -Q/-qfile\n"\
         "Use this if you want to compare a set of queries to a set of references rather than complete all-pairs. Note: -F must be provided, or reference files should be added as positional arguments\n"\
         "positional arguments and -F paths are treated as a reference set;\n"\
         "Paths provided in -Q/--qfile are are treated as a query set.\n"\

--- a/src/sketch_core.cpp
+++ b/src/sketch_core.cpp
@@ -67,17 +67,19 @@ SketchingResult sketch_core(Dashing2Options &opts, const std::vector<std::string
                     offset += bc[i].size();
                 }
             } else {
+                OMP_PFOR
                 for(size_t i = 0; i < npaths; ++i) {
                     auto myind = filesizes.size() ? filesizes[i].second: uint64_t(i);
                     auto &p(paths[myind]);
                     result.names_[i] = p;
-                    auto res = bw2sketch(p, opts, /*parallel_process=*/true);
+                    auto res = bw2sketch(p, opts, /*parallel_process=*/false);
                     std::copy(res.global_->begin(), res.global_->end(), &result.signatures_[myind * opts.sketchsize_]);
                     result.cardinalities_[myind] = res.card_;
                 }
             }
         }
     }
+#if 0
     if(paths.size() == 1 && outfile.empty()) {
         const std::string suf =
                 opts.sspace_ == SPACE_SET ? (opts.kmer_result_ == ONE_PERM ? ".opss": ".ss"):
@@ -94,6 +96,7 @@ SketchingResult sketch_core(Dashing2Options &opts, const std::vector<std::string
                 outfile = opts.outprefix_ + '/' + outfile;
         }
     }
+#endif
     bool even = (opts.kmer_result_ != FULL_MMER_SEQUENCE && (result.nperfile_.empty() || std::all_of(result.nperfile_.begin() + 1, result.nperfile_.end(), [v=result.nperfile_.front()](auto x) {return x == v;})));
     if(outfile.size()) {
         std::fprintf(stderr, "outfile %s\n", outfile.data());

--- a/src/sketch_core.cpp
+++ b/src/sketch_core.cpp
@@ -97,7 +97,7 @@ SketchingResult sketch_core(Dashing2Options &opts, const std::vector<std::string
         }
     }
 #endif
-    bool even = (opts.kmer_result_ != FULL_MMER_SEQUENCE && (result.nperfile_.empty() || std::all_of(result.nperfile_.begin() + 1, result.nperfile_.end(), [v=result.nperfile_.front()](auto x) {return x == v;})));
+    const bool even = (opts.kmer_result_ != FULL_MMER_SEQUENCE && (result.nperfile_.empty() || std::all_of(result.nperfile_.begin() + 1, result.nperfile_.end(), [v=result.nperfile_.front()](auto x) {return x == v;})));
     if(outfile.size()) {
         std::fprintf(stderr, "outfile %s\n", outfile.data());
         if(result.signatures_.empty()) THROW_EXCEPTION(std::runtime_error("Can't write stacked sketches if signatures were not generated"));

--- a/src/sketch_main.cpp
+++ b/src/sketch_main.cpp
@@ -67,7 +67,7 @@ int sketch_main(int argc, char **argv) {
     const std::string ex(std::filesystem::absolute(std::filesystem::path(argv[-1])));
     std::string cmd(ex);
     for(char **s = argv; *s; cmd += std::string(" ") + *s++);
-    std::fprintf(stderr, "[Dashing2] Invocation: %s ", cmd.data());
+    std::fprintf(stderr, "#Invocation: %s\n", cmd.data());
     if(nt < 0) {
         char *s = std::getenv("OMP_NUM_THREADS");
         if(s) nt = std::max(std::atoi(s), 1);

--- a/src/sketch_main.cpp
+++ b/src/sketch_main.cpp
@@ -46,7 +46,7 @@ int sketch_main(int argc, char **argv) {
     int by_chrom = false;
     double downsample_frac = 1.;
     uint64_t seedseed = 13;
-    size_t batch_size = 16;
+    size_t batch_size = 0;
     int nLSH = 2;
     Measure measure = SIMILARITY;
     std::ios_base::sync_with_stdio(false);
@@ -125,7 +125,7 @@ int sketch_main(int argc, char **argv) {
     if(cmpout.size()) {
         Dashing2DistOptions distopts(opts, ok, of, nbytes_for_fastdists, truncate_mode, topk_threshold, similarity_threshold, cmpout, exact_kmer_dist, refine_exact, nLSH);
         distopts.measure_ = measure;
-        distopts.cmp_batch_size_ = std::max(batch_size, size_t(distopts.nthreads()));
+        distopts.cmp_batch_size_ = default_batchsize(batch_size, distopts);
         cmp_core(distopts, result);
     }
     return 0;

--- a/src/sketch_main.cpp
+++ b/src/sketch_main.cpp
@@ -76,12 +76,16 @@ int sketch_main(int argc, char **argv) {
     std::vector<std::string> paths(argv + optind, argv + argc);
     std::unique_ptr<std::vector<std::string>> qup;
     if(ffile.size()) {
+        if(!bns::isfile(ffile)) THROW_EXCEPTION(std::runtime_error("No path found at "s + ffile));
         std::ifstream ifs(ffile);
         static constexpr size_t bufsize = 1<<18;
         std::unique_ptr<char []> buf(new char[bufsize]);
         ifs.rdbuf()->pubsetbuf(buf.get(), bufsize);
         for(std::string l;std::getline(ifs, l);) {
             paths.push_back(l);
+        }
+        if(paths.empty()) {
+            THROW_EXCEPTION(std::runtime_error("No paths read from "s + ffile));
         }
     }
     size_t nref = paths.size();

--- a/src/sketch_main.cpp
+++ b/src/sketch_main.cpp
@@ -63,14 +63,7 @@ int sketch_main(int argc, char **argv) {
         }
         //std::fprintf(stderr, "After getopt argument %d, of is %s\n",c , to_string(of).data());
     }
-    if(k < 0) {
-        if(rht == bns::DNA) k = 31;
-        else if(rht == bns::DNA2) k = 63;
-        else if(rht == bns::PROTEIN20) k = 14;
-        else if(rht == bns::PROTEIN_14) k = 16;
-        else if(rht == bns::PROTEIN_3BIT) k = 22;
-        else if(rht == bns::PROTEIN_6) k = 24;
-    }
+    if(k < 0) k = nregperitem(rht, use128);
     const std::string ex(std::filesystem::absolute(std::filesystem::path(argv[-1])));
     std::string cmd(ex);
     for(char **s = argv; *s; cmd += std::string(" ") + *s++);


### PR DESCRIPTION
For `dashing2 sketch --cmpout <path>` or `dashing2 cmp`, the default distance mode was PHYLIP upper-triangular.
This didn't match Dashing and could be confusing. Now, the default output mode matches Dashing (upper-triangular, with dashes to represent the diagonal and the lower triangular.

To get the PHYLIP output, use `--phylip`.

Besides this, there's additional error-handling, and automatic batch-size selection based on the sketch sizes and estimated  (largest) cache size.