### PR TITLE
Dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ read%-f: test/read%.fo $(FLIBOBJ)
 %.64o: %.c
 	$(CC) $(INC) $(OPTMV) $(WARNING) $(MACH) $< -c -o $@ $(LIB) $(EXTRA) -DNDEBUG -flto -O3 -DLSHIDTYPE="uint64_t" -std=c11
 %.0: %.cpp
-	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $< -c -o $@ $(LIB) $(EXTRA) -O0 -DNDEBUG
+	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $< -c -o $@ $(LIB) $(EXTRA) -O0
 %.0: %.c
 	$(CC) $(INC) $(OPTMV) $(WARNING) $(MACH) $< -c -o $@ $(LIB) $(EXTRA) -DNDEBUG -O0 -std=c11
 %.vo: %.cpp

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ dashing2-v: $(OBJV) libBigWig.a $(wildcard src/*.h)
 dashing2-d0: $(OBJDBG) libBigWig.a
 	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $(OBJDBG) -o $@ $(LIB) $(EXTRA) libBigWig.a -O0
 dashing2-add: $(OBJADD) libBigWig.a
-	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $(OBJADD) -o $@ $(LIB) $(EXTRA) libBigWig.a -fsanitize=thread
+	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $(OBJADD) -o $@ $(LIB) $(EXTRA) libBigWig.a -fsanitize=address
 dashing2-g: $(OBJG) libBigWig.a
 	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $(OBJG) -o $@ $(LIB) $(EXTRA) libBigWig.a -fno-lto -pg
 dashing2-ld: $(OBJLD) libBigWig.a
@@ -117,9 +117,9 @@ read%-f: test/read%.fo $(FLIBOBJ)
 %.do: %.c $(wildcard src/*.h)
 	$(CC) $(INC) $(OPTMV) $(WARNING) $(MACH) $< -c -o $@ $(LIB) $(EXTRA) -O0 -std=c11
 %.sano: %.cpp $(wildcard src/*.h)
-	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $< -c -o $@ $(LIB) $(EXTRA) -flto -fsanitize=address
+	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $< -c -o $@ $(LIB) $(EXTRA) -fsanitize=address -O1
 %.sano: %.c $(wildcard src/*.h)
-	$(CC) $(INC) $(OPTMV) $(WARNING) $(MACH) $< -c -o $@ $(LIB) $(EXTRA) -flto -fsanitize=address
+	$(CC) $(INC) $(OPTMV) $(WARNING) $(MACH) $< -c -o $@ $(LIB) $(EXTRA) -fsanitize=address -O1
 %.gobj: %.cpp $(wildcard src/*.h)
 	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $< -c -o $@ $(LIB) $(EXTRA) -pg -fno-lto -DNDEBUG
 %.ldo: %.cpp $(wildcard src/*.h)

--- a/src/bedsketch.cpp
+++ b/src/bedsketch.cpp
@@ -22,7 +22,7 @@ std::pair<std::vector<RegT>, double> bed2sketch(const std::string &path, const D
             cache_path = opts.outprefix_ + '/' + cache_path;
     }
     if(opts.cache_sketches_ && bns::isfile(cache_path)) {
-        std::FILE *ifp = xopen(cache_path);
+        auto [ifp, ispopen] = xopen(cache_path);
         std::fread(&ret.second, sizeof(ret.second), 1, ifp);
         while(!std::feof(ifp)) {
             RegT v;
@@ -30,7 +30,7 @@ std::pair<std::vector<RegT>, double> bed2sketch(const std::string &path, const D
             retvec.push_back(v);
         }
         ret.second = retvec.size() / std::accumulate(retvec.begin(), retvec.end(), 0.L);
-        ::pclose(ifp);
+        if(ispopen) ::pclose(ifp); else std::fclose(ifp);
         return ret;
     }
     for(std::string s;std::getline(ifs, s);) {

--- a/src/bwsketch.cpp
+++ b/src/bwsketch.cpp
@@ -43,15 +43,11 @@ BigWigSketchResult bw2sketch(std::string path, const Dashing2Options &opts, bool
     cache_path += opts.kmer_result_ <= FULL_SETSKETCH ? to_string(opts.sspace_): to_string(opts.kmer_result_);
     DBG_ONLY(std::fprintf(stderr, "Cache path: %s. isfile: %d\n", cache_path.data(), bns::isfile(cache_path));)
     if(opts.cache_sketches_ && !opts.by_chrom_ && bns::isfile(cache_path)) {
-        std::FILE *ifp = xopen(cache_path);
+        auto [ifp, ispopen] = xopen(cache_path);
         std::fread(&ret.card_, sizeof(ret.card_), 1, ifp);
         auto res = new std::vector<RegT>;
-        while(!std::feof(ifp)) {
-            RegT v;
-            std::fread(&v, sizeof(v), 1, ifp);
-            res->push_back(v);
-        }
-        ::pclose(ifp);
+        for(RegT v;std::fread(&v, sizeof(v), 1, ifp) == 1u;res->push_back(v));
+        if(ispopen) ::pclose(ifp); else std::fclose(ifp);
         ret.global_.reset(res);
         return ret;
     }

--- a/src/cmp_core.cpp
+++ b/src/cmp_core.cpp
@@ -45,6 +45,7 @@ std::string path2cmd(const std::string &path) {
 
 struct CompressedRet: public std::tuple<void *, long double, long double> {
     using super = std::tuple<void *, long double, long double>;
+    std::unique_ptr<uint8_t[]> up;
     size_t nbytes = 0;
     bool ismapped = 0;
     CompressedRet &a(long double v) {
@@ -59,20 +60,22 @@ struct CompressedRet: public std::tuple<void *, long double, long double> {
     long double b() const {return std::get<2>(*this);}
     CompressedRet(): super{nullptr, 0.L, 0.L} {
     }
-    CompressedRet(CompressedRet &&o): super(static_cast<super>(o)), nbytes(o.nbytes), ismapped(o.ismapped) {
-        o.nbytes = o.ismapped = std::get<1>(o) = std::get<2>(o) = 0.;
+    CompressedRet(CompressedRet &&o): super(static_cast<super>(o)), up(std::move(up)), nbytes(o.nbytes), ismapped(o.ismapped) {
+        o.nbytes = 0; o.ismapped = 0; std::get<1>(o) = 0.; std::get<2>(o) = 0.;
         std::get<0>(o) = 0;
     }
     CompressedRet(const CompressedRet &o) = delete;
-    ~CompressedRet() {
-        auto ptr = std::get<0>(*this);
-        std::fprintf(stderr, "Freeing memory at %p\n", (void *)ptr);
-        if(ismapped) {
-            if(ptr) ::munmap(ptr, nbytes);
-        } else std::free(ptr);
-        ptr = 0;
-    }
 };
+
+void *ptr_roundup(void *ptr) {
+    uint64_t tv((uint64_t)ptr);
+    auto rem = tv % 64;
+    if(rem) {
+        tv += (64 - rem);
+    }
+    ptr = (void *)tv;
+    return ptr;
+}
 
 CompressedRet
 make_compressed(int truncation_method, double fd, const mm::vector<RegT> &sigs, const mm::vector<uint64_t> &kmers, bool is_edit_distance) {
@@ -83,16 +86,8 @@ make_compressed(int truncation_method, double fd, const mm::vector<RegT> &sigs, 
     if(fd == 0. && std::fmod(fd * sigs.size(), 1.)) THROW_EXCEPTION(std::runtime_error("Can't do nibble registers without an even number of signatures"));
     auto &compressed_reps = std::get<0>(ret);
     std::fprintf(stderr, "nbytes to alloc: %zu\n", ret.nbytes);
-    if(ret.nbytes >= MEMSIGTHRESH) {
-        void *ptr = mm::AnonMMapper::allocate(ret.nbytes);
-        std::fprintf(stderr, "Allocated via mmap, ptr = %zu\n", (size_t)ptr);
-        if(reinterpret_cast<uint64_t>(ptr) == uint64_t(-1)) THROW_EXCEPTION(std::bad_alloc());
-        compressed_reps = ptr;
-        ret.ismapped = true;
-    } else {
-        if(posix_memalign((void **)&compressed_reps, 64, ret.nbytes)) THROW_EXCEPTION(std::bad_alloc());
-        std::fprintf(stderr, "Allocated via malloc, ptr = %zu\n", (size_t)compressed_reps);
-    }
+    ret.up.reset(new uint8_t[ret.nbytes + 63]);
+    compressed_reps = ptr_roundup(static_cast<void *>(ret.up.get()));
     const size_t nsigs = sigs.size();
     assert(fd != 0.5 || sigs.size() % 2 == 0);
     if(is_edit_distance) {

--- a/src/cmp_core.cpp
+++ b/src/cmp_core.cpp
@@ -39,7 +39,8 @@ std::string path2cmd(const std::string &path) {
     if(std::equal(path.rbegin(), path.rbegin() + 3, "zg.")) return "gzip -dc "s + path;
     if(std::equal(path.rbegin(), path.rbegin() + 3, "zx.")) return "xz -dc "s + path;
     if(std::equal(path.rbegin(), path.rbegin() + 4, "2zb.")) return "bzip2 -dc "s + path;
-    return "cat "s + path;
+    if(std::equal(path.rbegin(), path.rbegin() + 4, "tsz.")) return "zstd -dc "s + path;
+    return ""s;
 }
 
 struct CompressedRet: public std::tuple<void *, long double, long double> {
@@ -324,14 +325,22 @@ case v: {\
         const std::string &lpath = result.destination_files_[i], &rpath = result.destination_files_[j];
         if(lpath.empty() || rpath.empty()) THROW_EXCEPTION(std::runtime_error("Destination files for k-mers empty -- cannot load from disk"));
         std::FILE *lhk = 0, *rhk = 0, *lhn = 0, *rhn = 0;
-        std::string lcmd = path2cmd(lpath), rcmd = path2cmd(rpath);
-        if((lhk = ::popen(lcmd.data(), "r")) == nullptr) THROW_EXCEPTION(std::runtime_error("Failed to run lcmd '"s + lcmd + "'"));
-        if((rhk = ::popen(rcmd.data(), "r")) == nullptr) THROW_EXCEPTION(std::runtime_error("Failed to run rcmd '"s + rcmd + "'"));
+        std::string lcmd = path2cmd(lpath), rcmd = path2cmd(rpath), lkcmd, rkcmd;
+        lhk = lcmd.empty() ? bfopen(lpath.data(), "rb"): ::popen(lcmd.data(), "r");
+        rhk = rcmd.empty() ? bfopen(rpath.data(), "rb"): ::popen(rcmd.data(), "r");
+        if(lhk == 0) THROW_EXCEPTION(std::runtime_error("Failed to "s + (lcmd.empty() ? " read from "s + lpath: "Run cmd '"s + lcmd + "'")));
+        if(rhk == 0) THROW_EXCEPTION(std::runtime_error("Failed to "s + (rcmd.empty() ? " read from "s + rpath: "Run cmd '"s + rcmd + "'")));
         if(result.kmercountfiles_.size()) {
-            lcmd = path2cmd(result.kmercountfiles_[i]);
-            rcmd = path2cmd(result.kmercountfiles_[j]);
-            if((lhn = ::popen(lcmd.data(), "r")) == nullptr) THROW_EXCEPTION(std::runtime_error("Failed to run lcmd '"s + lcmd + "'"));
-            if((rhn = ::popen(rcmd.data(), "r")) == nullptr) THROW_EXCEPTION(std::runtime_error("Failed to run lcmd '"s + rcmd + "'"));
+            lkcmd = path2cmd(result.kmercountfiles_[i]);
+            rkcmd = path2cmd(result.kmercountfiles_[j]);
+            lhn = lkcmd.empty() ? bfopen(result.kmercountfiles_[i].data(), "rb"): ::popen(lkcmd.data(), "r");
+            if(rkcmd.empty()) {
+                rhn = bfopen(result.kmercountfiles_[j].data(), "rb");
+            } else {
+                rhn = ::popen(rkcmd.data(), "r");
+            }
+            if(lhn == nullptr) THROW_EXCEPTION(std::runtime_error("Failed to read from "s + result.kmercountfiles_[i]));
+            if(rhn == nullptr) THROW_EXCEPTION(std::runtime_error("Failed to read from "s + result.kmercountfiles_[j]));
         }
         if(opts.kmer_result_ == FULL_MMER_SEQUENCE) {
             if(opts.exact_kmer_dist_) {
@@ -348,8 +357,14 @@ case v: {\
             double res = isz_size;
             CORRECT_RES(res, opts.measure_, lhc, rhc)
         }
-        ::pclose(lhk); ::pclose(rhk);
-        if(lhn) ::pclose(lhn), ::pclose(rhn);
+        if(lcmd.empty()) std::fclose(lhk); else ::pclose(lhk);
+        if(rcmd.empty()) std::fclose(rhk); else ::pclose(rhk);
+        if(lhn) {
+            if(lkcmd.empty()) std::fclose(lhn); else ::pclose(lhn);
+        }
+        if(rhn) {
+            if(rkcmd.empty()) std::fclose(rhn); else ::pclose(rhn);
+        }
 #undef CORRECT_RES
         // Compare exact representations, not compressed shrunk
     }
@@ -391,14 +406,20 @@ void cmp_core(const Dashing2DistOptions &opts, SketchingResult &result) {
             int ft;
             std::FILE *ifp = nullptr;
             std::string fn = opts.kmer_result_ == FULL_MMER_SET ? result.kmerfiles_.at(i): result.destination_files_.at(i);
+            std::string cmd;
             if(opts.kmer_result_ == FULL_MMER_SET || opts.kmer_result_ == FULL_MMER_SEQUENCE) {
                 if(!check_compressed(fn, ft)) throw std::runtime_error(std::string("Missing kmerfile or destination file: ") + fn);
                 if(endswith(fn, ".xz")) ft = 2;
                 else if(endswith(fn, ".gz")) ft = 1;
                 else ft = 0;
-                std::string cmd = std::string(ft == 0 ? "cat ": ft == 1 ? "gzip -dc ": ft == 2 ? "xz -dc " : "unknowncommand") + fn;
-                if(!(ifp = ::popen(cmd.data(), "r")))
-                    THROW_EXCEPTION(std::runtime_error(std::string("Command ") + "'" + cmd + "' failed."));
+                cmd = std::string(ft == 0 ? "": ft == 1 ? "gzip -dc ": ft == 2 ? "xz -dc " : "unknowncommand") + fn;
+                if(cmd.empty()) {
+                    ifp = bfopen(fn.data(), "rb");
+                } else {
+                    ifp = ::popen(cmd.data(), "r");
+                }
+                if(!ifp)
+                    THROW_EXCEPTION(std::runtime_error("Failed to read from '"s + cmd + "' for file " + fn));
                 size_t c = 0;
                 for(uint64_t x;std::fread(&x, sizeof(x), 1, ifp) == 1u;++c)
                 result.cardinalities_[i] = c;
@@ -407,16 +428,24 @@ void cmp_core(const Dashing2DistOptions &opts, SketchingResult &result) {
                 if(endswith(result.kmercountfiles_[i], ".xz")) ft = 2;
                 else if(endswith(result.kmercountfiles_[i], ".gz")) ft = 1;
                 else ft = 0;
-                std::string cmd = ft == 0 ? "cat "s: ft == 1 ? "gzip -dc "s: ft == 2 ? "xz -dc "s : "unknowncommand"s;
+                cmd = ft == 0 ? ""s: ft == 1 ? "gzip -dc "s: ft == 2 ? "xz -dc "s : "unknowncommand"s;
                 if(cmd == "unknowncommand") THROW_EXCEPTION(std::runtime_error("Failure"));
-                cmd += result.kmercountfiles_[i];
-                if(!(ifp = ::popen(cmd.data(), "r")))
-                    THROW_EXCEPTION(std::runtime_error("Command '"s + cmd + "' failed."));
+                if(cmd.empty()) {
+                    ifp = bfopen(fn.data(), "rb");
+                } else {
+                    cmd += result.kmercountfiles_[i];
+                    ifp = ::popen(cmd.data(), "r");
+                }
+                if(0 == ifp)
+                    THROW_EXCEPTION(std::runtime_error(cmd.empty() ? "Parsing "s + fn : ": Command '"s + cmd + "' failed."));
                 double x, c, s;
                 for(x = c = s = 0.;std::fread(&x, sizeof(x), 1, ifp) == 1u;sketch::kahan::update(s, c, x));
                 result.cardinalities_[i] = s;
             }
-            if(ifp) ::pclose(ifp);
+            if(ifp) {
+                if(cmd.empty()) std::fclose(ifp);
+                else ::pclose(ifp);
+            }
         }
     }
     if(opts.kmer_result_ == ONE_PERM) {

--- a/src/cmp_main.h
+++ b/src/cmp_main.h
@@ -79,9 +79,6 @@ struct Dashing2DistOptions: public Dashing2Options {
         if(nLSH < 1) nLSH = 1;
         validate();
     }
-    ~Dashing2DistOptions() {
-        std::free(compressed_ptr_); compressed_ptr_ = 0;
-    }
     void validate() const {
         Dashing2Options::validate();
         if(num_neighbors_ > 0 && min_similarity_ > 0.) {

--- a/src/contain_main.cpp
+++ b/src/contain_main.cpp
@@ -20,27 +20,29 @@ int contain_usage() {
     return EXIT_FAILURE;
 }
 
-std::vector<flat_hash_map<uint64_t, uint64_t>> get_results(bns::Encoder<bns::score::Lex, uint64_t> &eenc, bns::RollingHasher<uint64_t> &renc, std::vector<std::string> input_files, const flat_hash_map<uint64_t, std::vector<uint64_t>> &kmer2ids, int nthreads) {
+std::vector<flat_hash_map<uint64_t, uint64_t>> get_results(bns::Encoder<bns::score::Lex, uint64_t> &eenc, bns::RollingHasher<uint64_t> &renc, std::vector<std::string> input_files, const flat_hash_map<uint64_t, std::vector<uint64_t>> &kmer2ids) {
     std::vector<flat_hash_map<uint64_t, uint64_t>> res(input_files.size());
-    KSeqHolder kseqs(nthreads);
+    //KSeqHolder kseqs(nthreads);
     OMP_PFOR_DYN
     for(size_t i = 0; i < input_files.size(); ++i) {
         auto &myres = res[i];
         auto func = [&](auto kmer) {
+            kmer = maskfn(kmer);
             auto kmeridit = kmer2ids.find(kmer);
             if(kmeridit == kmer2ids.end()) {
+                //std::fprintf(stderr, "Not in map, ignoring k-mer\n");
                 // We don't have to process any k-mers not in this set!
                 return;
             }
             auto it = myres.find(kmer);
-            if(it == myres.end()) myres.emplace(kmer, 1);
+            if(it == myres.end()) it = myres.emplace(kmer, 1).first;
             else ++it->second;
         };
-        const int tid = OMP_ELSE(omp_get_thread_num(), 1);
+        auto path = input_files[i].data();
         if(eenc.k() <= eenc.nremperres64()) {
-            eenc.for_each(func, input_files[i].data(), &kseqs[tid]);
+            eenc.for_each(func, path);
         } else {
-            renc.for_each_hash(func, input_files[i].data(), &kseqs[tid]);
+            renc.for_each_hash(func, path);
         }
     }
     return res;
@@ -67,19 +69,17 @@ int contain_main(int argc, char **argv) {
     if(nthreads > 1) omp_set_num_threads(nthreads);
 #endif
     auto diff = argc - optind;
-    std::string databasefile;
-    switch(diff) {
-        case 0: return contain_usage(); break;
-        case 1: databasefile = argv[optind];
-            if(streamfiles.empty()) {
-                streamfiles.push_back("/dev/stdin");
-                std::fprintf(stderr, "No input files provided; this defaults to stdin. If this is in error, cancel dashing2.\n");
-            }
-        break;
-        default: streamfiles.insert(streamfiles.end(), argv + optind + 1, argv + argc); break;
+    if(diff == 0) return contain_usage();
+    std::string databasefile = argv[optind];
+    streamfiles.insert(streamfiles.end(), argv + optind + 1, argv + argc);
+    if(streamfiles.empty()) {
+        streamfiles.push_back("/dev/stdin");
+        std::fprintf(stderr, "No input files provided; this defaults to stdin. If this is in error, cancel dashing2.\n");
     }
     const size_t nq = streamfiles.size();
+    static constexpr size_t headerlen = 24;
     mio::mmap_source db(databasefile);
+    assert(db.size() >= headerlen);
     const void *dbptr = (void *)db.data();
     bns::InputType rht = static_cast<bns::InputType>(*((uint32_t *)dbptr) & 0xFF);
     const bool canon = *(uint32_t *)dbptr & 0x100;
@@ -87,35 +87,45 @@ int contain_main(int argc, char **argv) {
     const uint32_t sketchsize = ((const uint32_t *)dbptr)[1];
     const uint32_t k = ((const uint32_t *)dbptr)[2];
     const uint32_t w = ((const uint32_t *)dbptr)[3];
-    if((db.size() - 16) % sketchsize) THROW_EXCEPTION(std::runtime_error("Database corrupted (not a multiple of uint64_t size). Regenerate?"));
+    const uint64_t seed = ((const uint64_t *)dbptr)[2];
+    seed_mask(seed);
+    if((db.size() - headerlen) % sketchsize) THROW_EXCEPTION(std::runtime_error("Database corrupted (not a multiple of uint64_t size). Regenerate?"));
     std::vector<std::string> names;
     {
         if(bns::isfile(databasefile + ".names.txt")) {
             std::ifstream ifs(databasefile + ".names.txt");
             for(std::string line;std::getline(ifs, line); names.emplace_back(line));
         } else {
-            const size_t v = ((db.size() - 16) / sketchsize);
+            const size_t v = ((db.size() - headerlen) / sketchsize);
             while(names.size() < v) names.push_back(std::to_string(v));
         }
     }
     const size_t nitems = names.size();
-    if(nitems != ((db.size() - 16) / sketchsize)) THROW_EXCEPTION(std::runtime_error("Database corrupted; wrong number of names."));
+    if(nitems != ((db.size() - headerlen) / sketchsize / sizeof(uint64_t))) THROW_EXCEPTION(std::runtime_error("Database corrupted; wrong number of names."));
     bns::Spacer sp(k, w);
     bns::Encoder<bns::score::Lex, uint64_t> e64(sp, nullptr, canon);
     bns::RollingHasher<uint64_t> rh64(k, canon, rht, w);
     flat_hash_map<uint64_t, std::vector<uint64_t>> kmer2ids;
+    dashing2::flat_hash_map<uint64_t, uint32_t> fhs;
     for(size_t i = 0; i < nitems; ++i) {
-        uint64_t *ptr = ((uint64_t *)dbptr + 2 + sketchsize * i);
-        for(size_t j = 0; j < sketchsize; ++j)
-            kmer2ids[ptr[j]].push_back(i);
+        uint64_t *ptr = ((uint64_t *)dbptr + 3 + sketchsize * i);
+        assert((const char *)ptr < &db.data()[db.size()]);
+        for(size_t j = 0; j < sketchsize; ++j) {
+            const auto v = ptr[j];
+            kmer2ids[v].push_back(i);
+            auto it = fhs.find(v);
+            if(it == fhs.end()) fhs.emplace(v, 1u);
+            else ++it->second;
+        }
+        fhs.clear();
     }
-    std::vector<flat_hash_map<uint64_t, uint64_t>> res = get_results(e64, rh64, streamfiles, kmer2ids, nthreads);
+    std::vector<flat_hash_map<uint64_t, uint64_t>> res = get_results(e64, rh64, streamfiles, kmer2ids);
     std::vector<float> coverage_mat(nitems * streamfiles.size());
     std::vector<float> coverage_stats(nitems * streamfiles.size());
     OMP_PFOR_DYN
     for(size_t i = 0; i < res.size(); ++i) {
-        std::vector<uint32_t> matches(nitems);
-        std::vector<uint32_t> matchsums(nitems);
+        std::unique_ptr<uint32_t[]> matches(new uint32_t[nitems]);
+        std::unique_ptr<uint32_t[]> matchsums(new uint32_t[nitems]);
         for(const auto &[key, value]: res[i]) {
             for(const auto refid: kmer2ids.at(key)) {
                 ++matches[refid];
@@ -138,8 +148,8 @@ int contain_main(int argc, char **argv) {
         std::fwrite(coverage_stats.data(), sizeof(float), coverage_mat.size(), ofp);
     } else {
         std::fprintf(ofp, "#Dashing2 contain - a list of coverage %%s for the set of references, + mean coverage levels.\n");
-        std::fprintf(stderr, "Each matrix entry consists of <coverage%%:mean depth of coverage>\n");
-        std::fprintf(ofp, "#References:");
+        std::fprintf(stderr, "#Each matrix entry consists of <coverage%%:mean depth of coverage>\n");
+        std::fprintf(ofp, "##References:");
         for(size_t i = 0; i < nitems; ++i) {
             std::fputc('\t', ofp);
             std::fwrite(names[i].data(), 1, names[i].size(), ofp);
@@ -150,7 +160,9 @@ int contain_main(int argc, char **argv) {
             const float *cmatptr = &coverage_mat[nitems * i];
             const float *cstatsptr = &coverage_stats[nitems * i];
             for(size_t j = 0; j < nitems; ++j) {
-                std::fprintf(ofp, "\t%0.8g%%:%0.4g", cmatptr[j], cstatsptr[j]);
+                assert(cmatptr + j < &*coverage_mat.end());
+                assert(cstatsptr + j < &*coverage_stats.end());
+                std::fprintf(ofp, "\t%0.8g%%:%0.4g", 100. * cmatptr[j], cstatsptr[j]);
             }
             std::fputc('\n', ofp);
         }

--- a/src/d2.cpp
+++ b/src/d2.cpp
@@ -2,6 +2,7 @@
 
 namespace dashing2 {
 int cmp_main(int argc, char **argv);
+int contain_main(int argc, char **argv);
 int wsketch_main(int argc, char **argv);
 int sketch_main(int argc, char **argv);
 std::string Dashing2Options::to_string() const {
@@ -125,7 +126,7 @@ int main(int argc, char **argv) {
         if(std::strcmp(argv[1], "wsketch") == 0)
             return wsketch_main(argc - 1, argv + 1);
         if(std::strcmp(argv[1], "contain") == 0)
-            return wsketch_main(argc - 1, argv + 1);
+            return contain_main(argc - 1, argv + 1);
     }
     return main_usage();
 }

--- a/src/d2.cpp
+++ b/src/d2.cpp
@@ -43,29 +43,39 @@ std::string Dashing2Options::to_string() const {
     return ret;
 }
 
-void Dashing2Options::filterset(std::string fsarg) {
+void Dashing2Options::filterset(const std::string &fsarg) {
     if(fsarg.empty()) return;
     auto i = fsarg.find_last_of(':');
     filterset(fsarg.substr(0, i), (i != std::string::npos && static_cast<char>(fsarg[i + 1] & 0xdf) != 'K'));
 }
 
-void Dashing2Options::filterset(std::string path, bool is_kmer) {
+void Dashing2Options::filterset(const std::string &path, bool is_kmer) {
     fs_.reset(new FilterSet());
     if(is_kmer) {
         std::string cmd;
         if(endswith(path, ".xz")) cmd = "xz -dc ";
         else if(endswith(path, ".gz")) cmd = "gzip -dc ";
         else if(endswith(path, ".bz2")) cmd = "bzip2 -dc ";
-        else cmd = "cat ";
-        cmd += path;
-        std::FILE *ifp = ::popen(cmd.data(), "r");
+        else if(endswith(path, ".zst")) cmd = "zstd -dc ";
+        else cmd = "";
+        std::FILE *ifp;
+        if(cmd.empty()) {
+            if((ifp = bfopen(cmd.data(), "rb")) == 0)
+                THROW_EXCEPTION(std::runtime_error("Failed to open file "s + path + " for reading"));
+        } else {
+            if((ifp= ::popen((cmd + path).data(), "r")) == 0)
+                THROW_EXCEPTION(std::runtime_error("Failed to run command "s + cmd + path));
+        }
         uint64_t u6; u128_t u12;
         void *const ptr = use128() ? (void *)&u12: (void *)&u6;
         for(const auto is(use128() ? 16: 8);std::fread(ptr, is, 1, ifp) == 1;) {
             if(use128()) fs_->add(u12);
             else         fs_->add(u6);
         }
-        ::pclose(ifp);
+        if(cmd.empty())
+            std::fclose(ifp);
+        else
+            ::pclose(ifp);
     } else {
         for_each_substr([&](const std::string &subpath) {
             //std::fprintf(stderr, "Doing for_each_substr for subpath = %s\n", subpath.data());
@@ -103,16 +113,16 @@ bool entmin = false;
 } // dashing2
 
 int main_usage() {
-    std::fprintf(stderr, "dashing2 has several subcommands\n");
-    std::fprintf(stderr, "Usage can be seen in those commands.\n\n");
+    std::fprintf(stderr, "dashing2 has several subcommands: sketch, cmp, wsketch, and contain.\n");
+    std::fprintf(stderr, "Usage can be seen in those subcommands. (e.g., `dashing2 sketch -h`)\n\n");
     std::fprintf(stderr, "\tsketch: converts FastX into k-mer sets/sketches, and sketches BigWig and BED files; also contains functionality from cmp, for one-step sketch and comparisons\n"
                          "This is probably the most common subcommand to use.\n\n"
     );
     std::fprintf(stderr, "\tcmp: compares previously sketched/decomposed k-mer sets and emits results. alias: dist\n\n");
+    std::fprintf(stderr, "\tcontain: Takes a k-mer database (built with dashing2 sketch --save-kmers), then computes coverage for all k-mer references using input streams.\n");
     std::fprintf(stderr, "\twsketch: Takes a tuple of [1-3] input binary files [(u32 or u64), (float or double), (u32 or u64)] and performs weighted minhash sketching.\n"
                          "Three files are treated as Compressed Sparse Row (CSR)-format, where the third file contains indptr values, specifying the lengths of consecutive runs of pairs in the first two files corresponding to each row.\n"
                          "wsketch is for sketching binary files which have already been summed, whereas sketch is for parsing and sketching (from Fast{qa}, BED, BigWig)\n");
-    std::fprintf(stderr, "contain: Takes a k-mer database (built with dashing2 sketch --save-kmers), then computes coverage for all k-mer references using input streams.\n");
     return 1;
 }
 using namespace dashing2;

--- a/src/d2.cpp
+++ b/src/d2.cpp
@@ -112,6 +112,7 @@ int main_usage() {
     std::fprintf(stderr, "\twsketch: Takes a tuple of [1-3] input binary files [(u32 or u64), (float or double), (u32 or u64)] and performs weighted minhash sketching.\n"
                          "Three files are treated as Compressed Sparse Row (CSR)-format, where the third file contains indptr values, specifying the lengths of consecutive runs of pairs in the first two files corresponding to each row.\n"
                          "wsketch is for sketching binary files which have already been summed, whereas sketch is for parsing and sketching (from Fast{qa}, BED, BigWig)\n");
+    std::fprintf(stderr, "contain: Takes a k-mer database (built with dashing2 sketch --save-kmers), then computes coverage for all k-mer references using input streams.\n");
     return 1;
 }
 using namespace dashing2;

--- a/src/d2.h
+++ b/src/d2.h
@@ -192,8 +192,8 @@ public:
         OMP_ONLY(omp_set_num_threads(nt);)
         return *this;
     }
-    void filterset(std::string path, bool is_kmer);
-    void filterset(std::string fsarg);
+    void filterset(const std::string &path, bool is_kmer);
+    void filterset(const std::string &fsarg);
     CountingType ct() const {return cssize_ > 0 ? COUNTMIN_COUNTING: EXACT_COUNTING;}
     CountingType count() const {return ct();}
     bool trim_folder_paths() const {

--- a/src/enums.cpp
+++ b/src/enums.cpp
@@ -71,8 +71,9 @@ void checked_fwrite(std::FILE *const fp, const void *const ptr, const size_t nb)
          throw std::runtime_error(std::string("[E:") + __PRETTY_FUNCTION__ + ':' + __FILE__ + std::to_string(__LINE__) + "] Failed to perform buffered write of " + std::to_string(static_cast<size_t>(nb)) + " bytes, instead writing " + std::to_string(lrc) + " bytes");
 }
 
-std::FILE *xopen(const std::string &path) {
+std::pair<std::FILE *, int> xopen(const std::string &path) {
     std::FILE *fp;
+    int ispopen = 1;
     if(path.size() > 3 && std::equal(path.data() + path.size() - 3, &path[path.size()], ".xz")) {
         auto cmd = std::string("xz -dc ") + path;
         fp = ::popen(cmd.data(), "r");
@@ -83,9 +84,10 @@ std::FILE *xopen(const std::string &path) {
         auto cmd = std::string("bzip2 -dc ") + path;
         fp = ::popen(cmd.data(), "r");
     } else {
-        fp = ::popen((std::string("cat ") + path).data(), "r");
+        ispopen = 0;
+        fp = bfopen(path.data(), "r");
     }
-    return fp;
+    return {fp, ispopen};
 }
 long signed int BLKSIZE = -1;
 std::mutex blksizelock;

--- a/src/enums.h
+++ b/src/enums.h
@@ -109,7 +109,7 @@ struct Dashing2Options;
 
 std::string to_suffix(const Dashing2Options &opts);
 void checked_fwrite(std::FILE *fp, const void *src, const size_t nb);
-std::FILE *xopen(const std::string &path);
+std::pair<std::FILE *, int> xopen(const std::string &path);
 
 extern uint64_t XORMASK;
 extern u128_t XORMASK2;

--- a/src/fastxsketch.cpp
+++ b/src/fastxsketch.cpp
@@ -201,7 +201,7 @@ FastxSketchingResult &fastx2sketch(FastxSketchingResult &ret, Dashing2Options &o
         }
     }
     if(kmeroutpath.size()) {
-        std::FILE *fp = std::fopen(kmeroutpath.data(), "w");
+        std::FILE *fp = bfopen(kmeroutpath.data(), "w");
         uint32_t dtype = (uint32_t)opts.input_mode() | (int(opts.canonicalize()) << 8);
         uint32_t sketchsize = opts.sketchsize_;
         uint32_t k = opts.k_;

--- a/src/fastxsketch.cpp
+++ b/src/fastxsketch.cpp
@@ -486,7 +486,6 @@ do {\
             std::FILE * ofp;
             if((ofp = bfopen(destination.data(), "wb")) == nullptr)
                 THROW_EXCEPTION(std::runtime_error(std::string("Failed to open file") + destination + "for writing minimizer sequence"));
-            checked_fwrite(ofp, &ret.cardinalities_[myind], sizeof(double));
             if(opss.empty() && fss.empty()) THROW_EXCEPTION(std::runtime_error("Both opss and fss are empty\n"));
             const size_t opsssz = opss.size();
             if(opsssz) {
@@ -503,6 +502,8 @@ do {\
                 perf_for_substrs([p=&fss[tid]](auto hv) {p->update(hv);});
                 ret.cardinalities_[myind] = fss[tid].getcard();
             }
+            checked_fwrite(ofp, &ret.cardinalities_[myind], sizeof(double));
+            std::fflush(ofp);
             const uint64_t *ids = nullptr;
             const uint32_t *counts = nullptr;
             const RegT *ptr = opsssz ? opss[tid].data(): fss[tid].data();

--- a/src/fastxsketch.cpp
+++ b/src/fastxsketch.cpp
@@ -210,9 +210,11 @@ FastxSketchingResult &fastx2sketch(FastxSketchingResult &ret, Dashing2Options &o
         checked_fwrite(fp, &sketchsize, sizeof(sketchsize));
         checked_fwrite(fp, &k, sizeof(k));
         checked_fwrite(fp, &w, sizeof(w));
+        checked_fwrite(fp, &opts.seedseed_, sizeof(opts.seedseed_));
         std::fclose(fp);
-        if(bns::filesize(kmeroutpath.data()) != 16) THROW_EXCEPTION(std::runtime_error("kmer out path is the wrong size (expected 16, got "s + std::to_string(bns::filesize(kmeroutpath.data()))));
-        ret.kmers_.assign(kmeroutpath, sizeof(uint32_t) * 4);
+        if(bns::filesize(kmeroutpath.data()) != 24) THROW_EXCEPTION(std::runtime_error("kmer out path is the wrong size (expected 16, got "s + std::to_string(bns::filesize(kmeroutpath.data()))));
+        static_assert(sizeof(uint32_t) * 4 + sizeof(uint64_t) == 24, "Sanity check");
+        ret.kmers_.assign(kmeroutpath, 24);
         if((fp = bfopen(kmernamesoutpath.data(), "wb")) == 0) THROW_EXCEPTION(std::runtime_error("Failed to open "s + kmernamesoutpath + " for writing."));
         for(const auto &n: paths) {
             std::fwrite(n.data(), 1, n.size(), fp);

--- a/src/refine.cpp
+++ b/src/refine.cpp
@@ -7,7 +7,7 @@ void refine_results(std::vector<pqueue> &lists, const Dashing2DistOptions &opts,
     // 1. Perform full distance computations over the LSH-selected candidates
     if(opts.refine_exact_ && !opts.exact_kmer_dist_) {
         if(opts.kmer_result_ <= FULL_SETSKETCH && opts.compressed_ptr_) {
-            std::free(opts.compressed_ptr_), opts.compressed_ptr_ = 0;
+            opts.compressed_ptr_ = 0;
         } else {
             opts.exact_kmer_dist_ = true;
         }

--- a/src/sketch_core.cpp
+++ b/src/sketch_core.cpp
@@ -142,7 +142,7 @@ SketchingResult &sketch_core(SketchingResult &result, Dashing2Options &opts, con
             }
         }
     }
-    if(result.names_.size()) {
+    if(!outfile.empty() && result.names_.size()) {
         if((ofp = bfopen((outfile + ".names.txt").data(), "wb")) == nullptr)
             THROW_EXCEPTION(std::runtime_error(std::string("Failed to open outfile at ") + outfile + ".names.txt"));
         std::fputs("#Name\tCardinality\n", ofp);
@@ -158,7 +158,7 @@ SketchingResult &sketch_core(SketchingResult &result, Dashing2Options &opts, con
         }
         std::fclose(ofp);
     }
-    if(result.kmercounts_.size()) {
+    if(!outfile.empty() && result.kmercounts_.size()) {
         const size_t nb = result.kmercounts_.size() * sizeof(decltype(result.kmercounts_)::value_type);
         DBG_ONLY(std::fprintf(stderr, "Writing kmercounts of size %zu\n", result.kmercounts_.size());)
         if((ofp = bfopen((outfile + ".kmercounts.f64").data(), "wb"))) {

--- a/src/sketch_core.cpp
+++ b/src/sketch_core.cpp
@@ -129,7 +129,7 @@ SketchingResult &sketch_core(SketchingResult &result, Dashing2Options &opts, con
         if(outfile.size() && outfile != "/dev/stdout" && outfile != "-") {
             // This should not overlap with the memory mapped for result.signatures_
             const uint64_t t = result.cardinalities_.size();
-            std::FILE *fp = std::fopen(outfile.data(), "r+");
+            std::FILE *fp = bfopen(outfile.data(), "r+");
             if(!fp) THROW_EXCEPTION(std::runtime_error("Failed to open file "s + outfile + " for in-place modification"));
             const uint64_t sketchsize = opts.sketchsize_;
             checked_fwrite(fp, &t, sizeof(t));

--- a/src/wsketch.cpp
+++ b/src/wsketch.cpp
@@ -92,7 +92,7 @@ struct FReader{
     bool pclose = true;
     FReader(std::string path): path_(path), fp_(nullptr) {
         std::fprintf(stderr, "Reading from %s\n", path.data());
-        std::string c = "cat ";
+        std::string c;
         if(endswith(path, ".gz"))
             c = "gzip -dc ";
         else if(endswith(path, ".xz"))
@@ -105,7 +105,7 @@ struct FReader{
             return;
         }
         c += path;
-        std::fprintf(stderr, "Using cmd = '%s'\n", c.data());
+        //std::fprintf(stderr, "Using cmd = '%s'\n", c.data());
         if((fp_ = ::popen(c.data(), "r")) == nullptr)
             THROW_EXCEPTION(std::runtime_error(std::string("Failed to run cmd '") + c + "'"));
     }


### PR DESCRIPTION
Memory management tweaks/details;

1. If a file exists, use std::fopen instead of ::popen("cat "s + path) to read it, and then close with std::fclose instead of ::pclose.
2. Avoid moving CompressedReps, which prevents errors on some architectures.
3. For compressed reps, use unique_ptr<uint8_t[]> with manual ptr alignment instead of posix_memalign.
4. Use aligned allocator for mm::vector in RAM mode.
5. dashing2 contain fixes.
6. Fix storage of cardinality for OPSS and FSS.