### PR TITLE
Add fasta-format de-duplication in --parse-by-seq mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,29 +149,29 @@ bwf:
 
 libgomp.a:
 	ln -sf $(shell $(CXX) --print-file-name=libgomp.a)
-dashing2_s128: $(D2SRC) $(wildcard src/*.h) libgomp.a $(BWF) src/osfmt.o
+dashing2_s128: $(D2SRC) $(wildcard src/*.h) libgomp.a $(BWF) fmt/src/os.cc
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mno-avx512dq -mno-avx512vl -mno-avx512f -mno-avx512bw -mno-avx -mno-avx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
-    src/osfmt.o libgomp.a $(BWF) \
+    fmt/src/os.cc libgomp.a $(BWF) \
 		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
 
-dashing2_savx: $(D2SRC) $(wildcard src/*.h) src/osfmt.o libgomp.a $(BWF) src/osfmt.o
+dashing2_savx: $(D2SRC) $(wildcard src/*.h) fmt/src/os.cc libgomp.a $(BWF)
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mno-avx512dq -mno-avx512vl -mno-avx512f -mno-avx512bw -mavx -mno-avx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
-    src/osfmt.o libgomp.a $(BWF) \
+    fmt/src/os.cc libgomp.a $(BWF) \
 		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
 
-dashing2_savx2: $(D2SRC) $(wildcard src/*.h) src/osfmt.o libgomp.a $(BWF) src/osfmt.o
+dashing2_savx2: $(D2SRC) $(wildcard src/*.h) fmt/src/os.cc libgomp.a $(BWF)
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mno-avx512dq -mno-avx512vl -mno-avx512f -mno-avx512bw -mavx -mavx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
-    src/osfmt.o libgomp.a $(BWF) \
+    fmt/src/os.cc libgomp.a $(BWF) \
 		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
 
-dashing2_s512: $(D2SRC) $(wildcard src/*.h) src/osfmt.o libgomp.a $(BWF) src/osfmt.o
+dashing2_s512: $(D2SRC) $(wildcard src/*.h) fmt/src/os.cc libgomp.a $(BWF)
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mno-avx512dq -mno-avx512vl -mno-avx512bw -mavx512f -mavx -mavx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
-    src/osfmt.o libgomp.a $(BWF) \
+    fmt/src/os.cc libgomp.a $(BWF) \
 		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
 
-dashing2_s512bw: $(D2SRC) $(wildcard src/*.h) src/osfmt.o libgomp.a $(BWF) src/osfmt.o
+dashing2_s512bw: $(D2SRC) $(wildcard src/*.h) fmt/src/os.cc libgomp.a $(BWF)
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mavx512dq -mavx512vl -mavx512bw -mavx512f -mavx -mavx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
-    src/osfmt.o libgomp.a $(BWF) -DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
+    fmt/src/os.cc libgomp.a $(BWF) -DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
 
 dashing2_static: dashing2_s128 dashing2_savx dashing2_savx2 dashing2_s512 dashing2_s512bw
 static: dashing2_static

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ libgomp.a:
 dashing2_s128: $(D2SRC) $(wildcard src/*.h) libgomp.a $(BWF) src/osfmt.o
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mno-avx512dq -mno-avx512vl -mno-avx512f -mno-avx512bw -mno-avx -mno-avx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
     src/osfmt.o libgomp.a $(BWF) \
-		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz -O0
+		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
 
 dashing2_savx: $(D2SRC) $(wildcard src/*.h) src/osfmt.o libgomp.a $(BWF) src/osfmt.o
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mno-avx512dq -mno-avx512vl -mno-avx512f -mno-avx512bw -mavx -mno-avx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
@@ -171,7 +171,7 @@ dashing2_s512: $(D2SRC) $(wildcard src/*.h) src/osfmt.o libgomp.a $(BWF) src/osf
 
 dashing2_s512bw: $(D2SRC) $(wildcard src/*.h) src/osfmt.o libgomp.a $(BWF) src/osfmt.o
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mavx512dq -mavx512vl -mavx512bw -mavx512f -mavx -mavx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
-    src/osfmt.o libgomp.a $(BWF) -DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz -O0
+    src/osfmt.o libgomp.a $(BWF) -DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
 
 dashing2_static: dashing2_s128 dashing2_savx dashing2_savx2 dashing2_s512 dashing2_s512bw
 static: dashing2_static

--- a/python/parse.py
+++ b/python/parse.py
@@ -106,7 +106,7 @@ def pairwise_equality_compare(input_matrix, nthreads=1):
         idx = 0
         for i in range(nr):
             lc = nr - i - 1
-            ret[idx:idx + lc] = np.sum(input_matrix[i] == input_matrix[i + 1, nr], axis=1)
+            ret[idx:idx + lc] = np.sum(input_matrix[i] == input_matrix[i + 1:nr], axis=1)
             idx += lc
         return ret
 
@@ -125,4 +125,22 @@ def parse_binary_clustering(path, d64=False):
     return [indices[start:end] for start, end in zip(indptr[:-1], indptr[1:])]
 
 
-__all__ = ["parse_knn", "parse_binary_signatures", "ParsedSignatureMatrix", "parse_binary_kmers", "ParsedKmerMatrix", "alphabetcvt", "pairwise_equality_compare", "parse_binary_clustering"]
+def parse_binary_distmat(path):
+    '''
+    Parse all-pairs distances from binary distance matrix at <path>.
+    '''
+    return np.memmap(path, np.float32)
+
+
+def parse_binary_rectmat(path, fpath, qpath):
+    '''
+    Parse distance matrix from path using <fpath> and <qpath> as reference/query pairs.
+    fpath must have been provided to Dashing2 with -F/--ffile
+    qpath must have been provided to Dashing2 with -Q/--qfile
+    '''
+    ffiles, qfiles = map(lambda x: list(map(str.strip, open(x))), (fpath, qpath))
+    nref, nquery = map(len, (ffiles, qfiles))
+    return np.memmap(path, np.float32).reshape(nref, nquery)
+
+
+__all__ = ["parse_knn", "parse_binary_signatures", "ParsedSignatureMatrix", "parse_binary_kmers", "ParsedKmerMatrix", "alphabetcvt", "pairwise_equality_compare", "parse_binary_clustering", "parse_binary_distmat", "parse_binary_rectmat"]

--- a/src/cmp_core.cpp
+++ b/src/cmp_core.cpp
@@ -491,7 +491,7 @@ case v: {\
 #undef CORRECT_RES
         // Compare exact representations, not compressed shrunk
     }
-    if(std::isnan(ret) || std::isinf(ret)) ret = std::numeric_limits<double>::max();
+    if(std::isnan(ret) || std::isinf(ret)) ret = std::numeric_limits<decltype(ret)>::max();
     return ret;
 }
 
@@ -651,7 +651,8 @@ void cmp_core(const Dashing2DistOptions &opts, SketchingResult &result) {
         } else if(!distance(opts.measure_)) {
             OMP_PFOR
             for(size_t i = 0; i < neighbor_lists.size(); ++i) {
-                auto beg = neighbor_lists[i].begin(), e = neighbor_lists[i].end();
+                auto &nl = neighbor_lists[i];
+                auto beg = nl.begin(), e = nl.end();
                 std::transform(beg, e, beg, [&](PairT x) {return PairT{-x.first, x.second};});
             }
         }

--- a/src/cmp_main.cpp
+++ b/src/cmp_main.cpp
@@ -167,6 +167,7 @@ int cmp_main(int argc, char **argv) {
     Measure measure = SIMILARITY;
     uint64_t seedseed = 0;
     size_t batch_size = 0;
+    bool fasta_dedup = false;
     std::string spacing;
     // By default, use full hash values, but allow people to enable smaller
     OutputFormat of = OutputFormat::HUMAN_READABLE;
@@ -210,7 +211,8 @@ int cmp_main(int argc, char **argv) {
         .parse_by_seq(parse_by_seq)
         .count_threshold(count_threshold)
         .homopolymer_compress_minimizers(hpcompress)
-        .seedseed(seedseed);
+        .seedseed(seedseed)
+        .fasta_dedup(fasta_dedup);
     opts.by_chrom_ = by_chrom;
     if(hpcompress) {
         if(!opts.homopolymer_compress_minimizers_) THROW_EXCEPTION(std::runtime_error("Failed to hpcompress minimizers"));

--- a/src/d2.h
+++ b/src/d2.h
@@ -120,6 +120,7 @@ public:
     DataType dtype_;
     bool use128_ = false;
     unsigned nthreads_;
+    bool fasta_dedup_ = false;
 
     std::unique_ptr<FilterSet> fs_;
     Dashing2Options(int k, int w=-1, bns::RollingHashingType rht=bns::DNA, SketchSpace space=SPACE_SET, DataType dtype=FASTX, size_t nt=0, bool use128=false, std::string spacing="", bool canon=false, KmerSketchResultType kres=ONE_PERM):
@@ -154,6 +155,7 @@ public:
     D2O2(kmer_result) D2O2(use128) D2O2(cache_sketches)
     D2O2(sketchsize) D2O2(cssize) D2O2(parse_by_seq)
     D2O2(count_threshold)
+    D2O2(fasta_dedup);
 #undef D2O
 #undef D2O2
     void downsample(double f) {

--- a/src/dedup_core.h
+++ b/src/dedup_core.h
@@ -3,6 +3,14 @@
 
 namespace dashing2 {
 extern int exhaustive_dedup;
+extern int maxcand_global;
+
+#ifndef EARLYSTOP
+#define EARLYSTOP 1
+#endif
+static constexpr bool earlystop = EARLYSTOP;
+size_t default_candidates(const size_t nitems);
+
 }
 
 #endif

--- a/src/enums.h
+++ b/src/enums.h
@@ -52,7 +52,7 @@ enum CountingType {
 
 #define THROW_EXCEPTION(...) do {\
         auto exception__ = __VA_ARGS__;\
-        std::cerr << "Exception " << exception__.what() << " from " << std::this_thread::get_id() << '\n';\
+        std::cerr << "Exception " << exception__.what() << " from thread " << std::this_thread::get_id() << '\n';\
         throw exception__;\
     } while(0)
 

--- a/src/fastxsketchbyseq.cpp
+++ b/src/fastxsketchbyseq.cpp
@@ -120,7 +120,7 @@ FastxSketchingResult &fastx2sketch_byseq(FastxSketchingResult &ret, Dashing2Opti
     }, path);
     if(outpath.size() && outpath != "-" && outpath != "/dev/stdout") {
         if(!bns::isfile(outpath)) {
-            std::fprintf(stderr, "Creating outpath '%s'\n", outpath.data());
+            DBG_ONLY(std::fprintf(stderr, "Creating outpath '%s'\n", outpath.data());)
             std::FILE *fp = std::fopen(outpath.data(), "wb");
             if(!fp) THROW_EXCEPTION(std::runtime_error("Failed to open path "s + outpath + " for writing"));
             std::fclose(fp);

--- a/src/index_build.cpp
+++ b/src/index_build.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <mutex>
 #include "index_build.h"
+#include "dedup_core.h"
 
 namespace dashing2 {
 

--- a/src/index_build.cpp
+++ b/src/index_build.cpp
@@ -55,9 +55,10 @@ std::vector<pqueue> build_index(SetSketchIndex<LSHIDType, LSHIDType> &idx, const
     // Builds the LSH index and populates nearest-neighbor lists in parallel
     const size_t ns = result.names_.size();
     const int topk = opts.min_similarity_ > 0. ? -1: opts.num_neighbors_ > 0 ? 1: 0;
-    const LSHDistType INFLATE_FACTOR = 3.5;
+    static constexpr const LSHDistType INFLATE_FACTOR = 3.5;
     // Make the similarities negative so that the smallest items are the ones with the highest similarities
-    size_t ntoquery = opts.num_neighbors_ <= 0 ? ns - 1: std::min(ns - 1, size_t(opts.num_neighbors_ * INFLATE_FACTOR));
+    size_t ntoquery = opts.num_neighbors_ <= 0 ? (maxcand_global <= 0 ? ns - 1: size_t(maxcand_global))
+                                               : std::min(ns - 1, size_t(opts.num_neighbors_ * INFLATE_FACTOR));
     std::vector<pqueue> neighbor_lists(ns);
     if(opts.output_kind_ == KNN_GRAPH && opts.num_neighbors_ > 0)
         for(auto &n: neighbor_lists)

--- a/src/options.h
+++ b/src/options.h
@@ -154,7 +154,10 @@ enum OptArg {
 #define GREEDY_FIELD case OPTARG_GREEDY: {\
     char *eptr;\
     ok = OutputKind::DEDUP; similarity_threshold = std::strtod(optarg, &eptr);\
-    if((*eptr | 32) == 'e') {exhaustive_dedup = true; std::fprintf(stderr, "Using exhaustive_dedup.\n");}\
+    for(;*eptr;++eptr) {\
+        if((*eptr | 32) == 'e') {exhaustive_dedup = true;}\
+        if((*eptr | 32) == 'f') {fasta_dedup = true;}\
+    }\
     break;\
 }
 
@@ -391,7 +394,12 @@ static constexpr const char *siglen =
         "Greedy HIT Clustering\n"\
         "This is enabled by a single parameter, --greedy <float (0-1]>, which determines the similarity threshold below which a new cluster is formed.\n"\
         "--greedy <float (0-1]> For greedy clustering by a given similarity threshold; this selects representative sequences or sequence sets.\n"\
-        "This uses an LSH index by default. To compare all points to all clusters, add E to the end of the flag. (e.g., '--greedy 0.8E')"\
+        "This uses an LSH index by default. \n"\
+        "    To compare all points to all clusters, add E to the end of the flag. (e.g., '--greedy 0.8E')"\
+        "    By default, this emits the names of the entities (sequence names, if --parse-by-seq, and filenames otherwise).\n"\
+        "    You may want to emit fasta-formatted output. You can do this by adding F to the end of the --greedy argument.\n"\
+        "    Example: '--greedy 0.8F' or '--greedy 0.8FE'.\n"\
+        "    This is only allowed for --parse-by-seq.\n"\
         "  As this number approaches 1, the number and uniformity of clusters grows.\n"\
         "  For human-readable, this emits one line per cluster listing its constituents, ordered by similarity\n"\
         "  For machine-readable, this file consists of 2 64-bit integers (nclusters, nsets), followed by (nclusters + 1) 64-bit integers, followed by nsets 64-bit integers, identifying which sets belonged to which clusters.\n"\

--- a/src/refine.cpp
+++ b/src/refine.cpp
@@ -37,9 +37,8 @@ void refine_results(std::vector<pqueue> &lists, const Dashing2DistOptions &opts,
                 beg = l.begin(), e = l.end();
             }
             if(size_t(opts.num_neighbors_) < l.size()) {
-                const auto fit = std::find_if(beg + opts.num_neighbors_, e, [bs=l[opts.num_neighbors_ - 1].first](const auto &x) {return x.first > bs;});
-                const auto olsz = l.size();
-                l.erase(fit, e);
+                l.erase(std::find_if(beg + opts.num_neighbors_, e, [bs=l[opts.num_neighbors_ - 1].first](const auto &x) {return x.first > bs;}),
+                        e);
             }
 
         } else if(opts.min_similarity_ > 0.) {

--- a/src/sketch_main.cpp
+++ b/src/sketch_main.cpp
@@ -28,6 +28,7 @@ int sketch_main(int argc, char **argv) {
     bool save_kmers = false, save_kmercounts = false, cache = false, use128 = false, canon = true;
     bool exact_kmer_dist = false, hpcompress = false;
     bool refine_exact = false;
+    bool fasta_dedup = false;
     double similarity_threshold = -1.;
     unsigned int count_threshold = 0.;
     size_t cssize = 0, sketchsize = 1024;
@@ -102,7 +103,8 @@ int sketch_main(int argc, char **argv) {
         .parse_by_seq(parse_by_seq)
         .count_threshold(count_threshold)
         .homopolymer_compress_minimizers(hpcompress)
-        .seedseed(seedseed);
+        .seedseed(seedseed)
+        .fasta_dedup(fasta_dedup);
     opts.by_chrom_ = by_chrom;
     opts.downsample(downsample_frac);
     if(hpcompress) {


### PR DESCRIPTION
In order to convert a larger sequence file into a de-duplicated fasta file, you can now append `F` to the `--greedy` argument.

For example: `--parse-by-seq --greedy 0.8F` will perform sequence deduplication on an input file with 80% similarity threshold, and emit a fasta file as output. Omitting the F will yield only the sequence names.