### PR TITLE
Sketch compressed - bug fix + byseq

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Dashing2 is the second version of the Dashing sequence sketching and comparison system.
 
 There have been several major changes, but you can still can get a quick start to compare a group of sequence collections [here](#quickstart).
-
+For instructions on parsing, see [Parsing](#parsing-code) below.
 [Installation instructions](#installation) can be found below.
 
 ### New Features

--- a/python/parse.py
+++ b/python/parse.py
@@ -52,9 +52,9 @@ def parse_binary_signatures(path):
     nseqs, sketchsize = map(int, dat[:16].view(np.uint64))
     cardinalities = dat[16:16 + (8 * nseqs)].view(np.float64)
     signatures = dat[16 + (8 * nseqs):].view(np.float64).reshape(nseqs, -1)
-    sigmul = sketchsize / signatures.shape[1]
-    if sigmul != 1.:
-        signatures = signatures.view({2: np.uint32, 1: np.uint64, 4: np.uint16, 8: np.uint8}[int(sigmul)])
+    sigmul = sketchsize // signatures.shape[1]
+    if sigmul != 1:
+        signatures = signatures.view({2: np.uint32, 1: np.uint64, 4: np.uint16, 8: np.uint8}[sigmul])
     return ParsedSignatureMatrix(nseqs, cardinalities, signatures)
 
 

--- a/python/parse.py
+++ b/python/parse.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 ParsedSignatureMatrix = namedtuple("ParsedSignatureMatrix", 'nseqs, cardinalities, signatures')
 ParsedKmerMatrix = namedtuple("ParsedKmerMatrix", 'k,w,canon,alphabet,sketchsize,seed,kmers')
 
+
 def parse_knn(path, idsize=4, dstsize=4):
     '''
 
@@ -50,7 +51,10 @@ def parse_binary_signatures(path):
     dat = np.memmap(path, np.uint8) # Map whole file
     nseqs, sketchsize = map(int, dat[:16].view(np.uint64))
     cardinalities = dat[16:16 + (8 * nseqs)].view(np.float64)
-    signatures = dat[16 + (8 * nseqs):].view(np.float64).reshape(-1, sketchsize)
+    signatures = dat[16 + (8 * nseqs):].view(np.float64).reshape(nseqs, -1)
+    sigmul = sketchsize / signatures.shape[1]
+    if sigmul != 1.:
+        signatures = signatures.view({2: np.uint32, 1: np.uint64, 4: np.uint16, 8: np.uint8}[int(sigmul)])
     return ParsedSignatureMatrix(nseqs, cardinalities, signatures)
 
 

--- a/src/cmp_main.cpp
+++ b/src/cmp_main.cpp
@@ -218,8 +218,7 @@ int cmp_main(int argc, char **argv) {
         if(!opts.homopolymer_compress_minimizers_) THROW_EXCEPTION(std::runtime_error("Failed to hpcompress minimizers"));
     }
     opts.filterset(fsarg);
-    if(nbytes_for_fastdists == 0.5)
-        opts.sketchsize_ += opts.sketchsize_ & 1; // Ensure that sketch size is a multiple of 2 if using nibbles
+    // Ensure we pad the number of registers to a multiple of 64 bits.
     opts.bed_parse_normalize_intervals_ = normalize_bed;
     opts.downsample(downsample_frac);
     Dashing2DistOptions distopts(opts, ok, of, nbytes_for_fastdists, truncate_mode, topk_threshold, similarity_threshold, cmpout, exact_kmer_dist, refine_exact, nLSH);

--- a/src/cmp_main.h
+++ b/src/cmp_main.h
@@ -106,11 +106,8 @@ struct Dashing2DistOptions: public Dashing2Options {
         if(sketch_compressed_set) {
             if(this->kmer_result_ != FULL_SETSKETCH)
                 THROW_EXCEPTION(std::invalid_argument("Sketch compressed is only available for FullSetSketch."));
-            if(fd_level_ < 1.)
-                THROW_EXCEPTION(std::invalid_argument("Cannot index nibble-sized registers currently. This may change."));
-            if(fd_level_ > 2.)
-                THROW_EXCEPTION(std::invalid_argument("Only permitting setsketch of 1 or 2 bytes per register."));
             if(this->compressed_b_ < 1.L) THROW_EXCEPTION(std::invalid_argument("base must be >= 1."));
+            if(this->compressed_a_ <= 0.L) THROW_EXCEPTION(std::invalid_argument("offset a must be > 0."));
         }
     }
 };

--- a/src/cmp_main.h
+++ b/src/cmp_main.h
@@ -81,6 +81,11 @@ struct Dashing2DistOptions: public Dashing2Options {
                 opts.sketchsize_ += sizeof(RegT) / opts.fd_level_ - rem;
                 std::fprintf(stderr, "Sketchsize is not %zu-bit register multiple; padding the number of registers to fit. New number of registers: %zu\n", sizeof(RegT) * 8, opts.sketchsize_);
             }
+            const size_t mul = 8 / nbytes_for_fastdists;
+            if(const size_t rem = opts.sketchsize_ % size_t(8 / nbytes_for_fastdists); rem) {
+                std::fprintf(stderr, "When sketching compressed, always pad to 64-bit sets.\n");
+                opts.sketchsize_ += mul - rem;
+            }
         }
         validate();
     }

--- a/src/d2.h
+++ b/src/d2.h
@@ -221,6 +221,9 @@ public:
         // Note: this always returns True after make_compressed (cmp_main.{h,cpp}) if --fastcmp is less than 8.
         // This is meant solely to be used during sketching
     }
+    int sigshift() const {
+        return (fd_level_ == 1. ? 3: fd_level_ == 2. ? 2: fd_level_ == 4. ? 1: fd_level_ == 0.5 ? 4: fd_level_ == 8 ? 0: -1) + (sizeof(RegT) == 16);
+    }
 };
 
 static INLINE bool endswith(std::string lhs, std::string rhs) {

--- a/src/enums.h
+++ b/src/enums.h
@@ -108,6 +108,9 @@ struct Dashing2Options;
 
 std::string to_suffix(const Dashing2Options &opts);
 void checked_fwrite(std::FILE *fp, const void *src, const size_t nb);
+inline void checked_fwrite(const void *ptr, const size_t itemsize, const size_t nitems, std::FILE *fp) {
+    checked_fwrite(fp, ptr, itemsize * nitems);
+}
 std::pair<std::FILE *, int> xopen(const std::string &path);
 
 extern uint64_t XORMASK;

--- a/src/fastxsketch.cpp
+++ b/src/fastxsketch.cpp
@@ -138,24 +138,6 @@ INLINE double compute_cardest(const RegT *ptr, const size_t m) {
     return m / s;
 }
 
-using sketch::setsketch::ByteSetS;
-using sketch::setsketch::ShortSetS;
-using sketch::setsketch::UintSetS;
-using VSetSketch = std::variant<ByteSetS, ShortSetS, UintSetS>;
-
-#if 0
-RegT *getdata(VSetSketch &o) {
-    RegT *ret;
-    std::visit([&ret](auto &x) {ret = (const RegT *)x.data();}, o);
-    return ret;
-}
-#endif
-
-const RegT *getdata(VSetSketch &o) {
-    const RegT *ret;
-    std::visit([&ret](auto &x) {ret = (const RegT *)x.data();}, o);
-    return ret;
-}
 
 
 
@@ -256,7 +238,7 @@ FastxSketchingResult &fastx2sketch(FastxSketchingResult &ret, Dashing2Options &o
         static_assert(sizeof(uint32_t) * 4 + sizeof(uint64_t) == 24, "Sanity check");
         ret.kmers_.assign(kmeroutpath, 24);
         for(const auto &n: paths) {
-            std::fwrite(n.data(), 1, n.size(), fp);
+            checked_fwrite(n.data(), 1, n.size(), fp);
             std::fputc('\n', fp);
         }
         std::fclose(fp);
@@ -458,7 +440,7 @@ do {\
                 }
             }
             std::FILE * ofp = bfopen(destination.data(), "wb");
-            std::fwrite(&ret.cardinalities_[myind], sizeof(ret.cardinalities_[myind]), 1, ofp);
+            checked_fwrite(&ret.cardinalities_[myind], sizeof(ret.cardinalities_[myind]), 1, ofp);
             if(!ofp) THROW_EXCEPTION(std::runtime_error(std::string("Failed to open std::FILE * at") + destination));
             const void *buf = nullptr;
             size_t nb;
@@ -591,8 +573,8 @@ do {\
                 counts = opsssz ? opss[tid].idcounts().data(): fss[tid].idcounts().data();
             if(opts.sketch_compressed()) {
                 std::array<long double, 4> arr{opts.compressed_a_, opts.compressed_b_, static_cast<long double>(opts.fd_level_), static_cast<long double>(opts.sketchsize_)};
-                std::fwrite(arr.data(), sizeof(long double), arr.size(), ofp);
-                std::fwrite(ptr, sizeof(RegT), ss >> sigshift, ofp);
+                checked_fwrite(arr.data(), sizeof(long double), arr.size(), ofp);
+                checked_fwrite(ptr, sizeof(RegT), ss >> sigshift, ofp);
             } else {
                 ::write(::fileno(ofp), ptr, regsize * ss);
             }

--- a/src/fastxsketch.cpp
+++ b/src/fastxsketch.cpp
@@ -5,6 +5,7 @@
 
 //#include <optional>
 namespace dashing2 {
+using namespace variation;
 
 
 void FastxSketchingResult::print() {
@@ -176,7 +177,9 @@ FastxSketchingResult &fastx2sketch(FastxSketchingResult &ret, Dashing2Options &o
             if(opts.sketch_compressed()) {
                 cfss.reserve(nt);
                 for(size_t i = 0; i < nt; ++i) {
-                    if(opts.fd_level_ == 1.) {
+                    if(opts.fd_level_ == .5) {
+                        cfss.emplace_back(NibbleSetS(ss, opts.compressed_b_, opts.compressed_a_));
+                    } else if(opts.fd_level_ == 1.) {
                         cfss.emplace_back(ByteSetS(ss, opts.compressed_b_, opts.compressed_a_));
                     } else if(opts.fd_level_ == 2.) {
                         cfss.emplace_back(ShortSetS(ss, opts.compressed_b_, opts.compressed_a_));
@@ -279,7 +282,7 @@ FastxSketchingResult &fastx2sketch(FastxSketchingResult &ret, Dashing2Options &o
     if(opts.kmer_result_ == FULL_MMER_SET) {
         ret.kmerfiles_.resize(ret.destination_files_.size());
     }
-    const int sigshift = (opts.fd_level_ == 1. ? 3: opts.fd_level_ == 2. ? 2: opts.fd_level_ == 4. ? 1: opts.fd_level_ == 0.5 ? 4: opts.fd_level_ == 8 ? 0: -1) + (sizeof(RegT) == 16);
+    const int sigshift = opts.sigshift();
     OMP_PFOR_DYN
     for(size_t i = 0; i < nitems; ++i) {
         int tid = 0;
@@ -574,13 +577,29 @@ do {\
             if(opts.sketch_compressed()) {
                 std::array<long double, 4> arr{opts.compressed_a_, opts.compressed_b_, static_cast<long double>(opts.fd_level_), static_cast<long double>(opts.sketchsize_)};
                 checked_fwrite(arr.data(), sizeof(long double), arr.size(), ofp);
-                checked_fwrite(ptr, sizeof(RegT), ss >> sigshift, ofp);
+                if(opts.fd_level_ == 0.5) {
+                    const uint8_t *srcptr = std::get<NibbleSetS>(cfss[tid]).data();
+                    for(size_t i = 0; i < opts.sketchsize_; i += 2) {
+                        uint8_t reg = (srcptr[i] << 4) | srcptr[i + 1];
+                        checked_fwrite(ptr, sizeof(reg), 1, ofp);
+                    }
+                } else {
+                    checked_fwrite(ptr, sizeof(RegT), ss >> sigshift, ofp);
+                }
             } else {
                 ::write(::fileno(ofp), ptr, regsize * ss);
             }
             std::fclose(ofp);
             if(ptr && ret.signatures_.size()) {
-                std::copy(ptr, ptr + (ss >> sigshift), &ret.signatures_[mss >> sigshift]);
+                if(opts.fd_level_ != .5) {
+                    std::copy(ptr, ptr + (ss >> sigshift), &ret.signatures_[mss >> sigshift]);
+                } else {
+                    const uint8_t *srcptr = std::get<NibbleSetS>(cfss[tid]).data();
+                    uint8_t *destptr = (uint8_t *)&ret.signatures_[mss >> sigshift];
+                    for(size_t i = 0; i < opts.sketchsize_; i += 2) {
+                        *destptr++ = (srcptr[i] << 4) | srcptr[i + 1];
+                    }
+                }
             }
             if(ids && ret.kmers_.size())
                 std::copy(ids, ids + ss, &ret.kmers_[mss]);

--- a/src/fastxsketch.cpp
+++ b/src/fastxsketch.cpp
@@ -246,12 +246,8 @@ FastxSketchingResult &fastx2sketch(FastxSketchingResult &ret, Dashing2Options &o
         }
         std::fclose(fp);
     }
-    size_t sigvecsize64 = ss * nitems;
-    if(opts.sketch_compressed()) {
-        const size_t regsper64 = sizeof(uint64_t) / opts.fd_level_;
-        sigvecsize64 = (sigvecsize64 + regsper64 - 1) / regsper64;
-    }
-    // File size before signatures:
+    const int sigshift = opts.sigshift();
+    const size_t sigvecsize64 = nitems * ss >> sigshift;
     ret.signatures_.resize(sigvecsize64);
     if(opts.sspace_ == SPACE_EDIT_DISTANCE) {
         THROW_EXCEPTION(std::runtime_error("edit distance is only available in parse by seq mode"));
@@ -282,7 +278,6 @@ FastxSketchingResult &fastx2sketch(FastxSketchingResult &ret, Dashing2Options &o
     if(opts.kmer_result_ == FULL_MMER_SET) {
         ret.kmerfiles_.resize(ret.destination_files_.size());
     }
-    const int sigshift = opts.sigshift();
     OMP_PFOR_DYN
     for(size_t i = 0; i < nitems; ++i) {
         int tid = 0;

--- a/src/fastxsketch.h
+++ b/src/fastxsketch.h
@@ -3,6 +3,7 @@
 #define DASHING2_FASTX_SKETCH_H__
 #include "d2.h"
 #include "mmvec.h"
+#include <variant>
 
 namespace dashing2 {
 using std::to_string;
@@ -59,15 +60,20 @@ using sketch::setsketch::ByteSetS;
 using sketch::setsketch::NibbleSetS;
 using sketch::setsketch::ShortSetS;
 using sketch::setsketch::UintSetS;
-using VSetSketch = std::variant<ByteSetS, ShortSetS, UintSetS>;
+using VSetSketch = std::variant<NibbleSetS, ByteSetS, ShortSetS, UintSetS>;
 
-const RegT *getdata(VSetSketch &o) {
+INLINE const RegT *getdata(VSetSketch &o) {
     const RegT *ret;
     std::visit([&ret](auto &x) {ret = (const RegT *)x.data();}, o);
     return ret;
 }
+INLINE double getcard(VSetSketch &o) {
+    double ret;
+    std::visit([&ret](auto &x) {ret = x.getcard();}, o);
+    return ret;
+}
 } // namespace variation
 using variation::VSetSketch;
-}
+} // namespace dashing2
 
 #endif

--- a/src/fastxsketch.h
+++ b/src/fastxsketch.h
@@ -53,6 +53,21 @@ using FastxSketchingResult = SketchingResult;
 FastxSketchingResult &fastx2sketch(FastxSketchingResult &res, Dashing2Options &opts, const std::vector<std::string> &paths, std::string path);
 FastxSketchingResult &fastx2sketch_byseq(FastxSketchingResult &res, Dashing2Options &opts, const std::string &path, kseq_t *kseqs, std::string outpath, bool parallel=false, const size_t seqs_per_batch = 8192);
 std::string makedest(Dashing2Options &opts, const std::string &path, bool iskmer=false);
+
+namespace variation {
+using sketch::setsketch::ByteSetS;
+using sketch::setsketch::NibbleSetS;
+using sketch::setsketch::ShortSetS;
+using sketch::setsketch::UintSetS;
+using VSetSketch = std::variant<ByteSetS, ShortSetS, UintSetS>;
+
+const RegT *getdata(VSetSketch &o) {
+    const RegT *ret;
+    std::visit([&ret](auto &x) {ret = (const RegT *)x.data();}, o);
+    return ret;
+}
+} // namespace variation
+using variation::VSetSketch;
 }
 
 #endif

--- a/src/fastxsketchbyseq.cpp
+++ b/src/fastxsketchbyseq.cpp
@@ -96,10 +96,6 @@ struct OptSketcher {
 void resize_fill(Dashing2Options &opts, FastxSketchingResult &ret, size_t newsz, std::vector<OptSketcher> &sketchvec, size_t &lastindex, size_t nthreads);
 
 FastxSketchingResult &fastx2sketch_byseq(FastxSketchingResult &ret, Dashing2Options &opts, const std::string &path, kseq_t *kseqs, std::string outpath, bool parallel, size_t seqs_per_batch) {
-
-    if(std::min(opts.compressed_a_, opts.compressed_b_) <= 0.L) {
-        THROW_EXCEPTION(std::invalid_argument("fastx sketchbyseq does not yet support pre-set SetSketch parameters."));
-    }
     gzFile ifp;
     kseq_t *myseq = kseqs ? &kseqs[OMP_ELSE(omp_get_thread_num(), 0)]: (kseq_t *)std::calloc(sizeof(kseq_t), 1);
     size_t batch_index = 0;

--- a/src/options.h
+++ b/src/options.h
@@ -52,6 +52,7 @@ enum OptArg {
     OPTARG_FASTCMPBYTES,
     OPTARG_FASTCMPSHORTS,
     OPTARG_FASTCMPWORDS,
+    OPTARG_FASTCMPNIBBLES,
     OPTARG_DUMMY
 };
 
@@ -115,8 +116,10 @@ enum OptArg {
     LO_FLAG("square", OPTARG_ASYMMETRIC_ALLPAIRS, ok, OutputKind::ASYMMETRIC_ALL_PAIRS)\
     LO_ARG("regbytes", OPTARG_FASTCMP)\
     /*LO_ARG("set", 'H')*/\
+    {"fastcmp-nibbles", no_argument, 0, OPTARG_FASTCMPNIBBLES},\
     {"fastcmp-bytes", no_argument, 0, OPTARG_FASTCMPBYTES},\
     {"fastcmp-shorts", no_argument, 0, OPTARG_FASTCMPSHORTS},\
+    {"fastcmp-words", no_argument, 0, OPTARG_FASTCMPWORDS},\
     {"save-kmers", no_argument, 0, 's'},\
     {"save-kmercounts", no_argument, 0, 'N'},\
     {"hp-compress", no_argument, 0, OPTARG_HPCOMPRESS},\
@@ -264,6 +267,11 @@ enum OptArg {
             compressed_a = sketch::setsketch::ByteSetS::DEFAULT_A;\
             compressed_b = sketch::setsketch::ByteSetS::DEFAULT_B;\
             nbytes_for_fastdists = 1.;\
+        } break;\
+        case OPTARG_FASTCMPNIBBLES: {\
+            compressed_a = sketch::setsketch::NibbleSetS::DEFAULT_A;\
+            compressed_b = sketch::setsketch::NibbleSetS::DEFAULT_B;\
+            nbytes_for_fastdists = .5;\
         } break;\
         case OPTARG_FASTCMPWORDS: {\
             compressed_a = sketch::setsketch::UintSetS::DEFAULT_A;\
@@ -455,6 +463,7 @@ static constexpr const char *siglen =
         "\t          --fastcmp-bytes sets a and b to 20 and 1.2, and sets --fastcmp to 1\n"\
         "\t          --fastcmp-shorts sets a and b to .06 and 1.0005, and sets --fastcmp to 2.\n"\
         "\t          --fastcmp-words sets a and b to 19.77 and 1.0000000109723500835 and sets --fastcmp to 4.\n"\
+        "\t          --fastcmp-nibbles sets a and b to .0005 and 2.71828, and sets --fastcmp to .5\n"\
         "\n"\
         "If you instead want to truncate to the bottom-b bits of the signature --\n"\
         "\t          --bbit-sigs: truncate to bottom-<arg> bytes of signatures instead of logarithmically-compressed.\n"\

--- a/src/setsketch.h
+++ b/src/setsketch.h
@@ -667,6 +667,8 @@ public:
     void print() const {
         std::fprintf(stderr, "%zu = m, a %lg, b %lg, q %d\n", m_, double(a_), double(b_), int(q_));
     }
+    template<typename OFT, typename=std::enable_if_t<std::is_arithmetic_v<OFT>>>
+    INLINE void update(const uint64_t id, OFT) {update(id);}
     void update(const uint64_t id) {
         using GenFT = std::conditional_t<(sizeof(FT) <= 8), double, long double>;
         GenFT carry = 0.;
@@ -858,19 +860,18 @@ public:
 };
 
 
-#ifndef M_E
-#define EULER_E 2.718281828459045
-#else
-#define EULER_E M_E
-#endif
 struct NibbleSetS: public SetSketch<uint8_t> {
-    NibbleSetS(size_t nreg, double b=EULER_E, double a=5e-4): SetSketch<uint8_t>(nreg, b, a, QV) {}
+    static constexpr long double DEFAULT_B = 2.7182818284590452354L;
+    static constexpr long double DEFAULT_A = 5e-4L;
+    NibbleSetS(size_t nreg, double b=DEFAULT_B, double a=DEFAULT_A): SetSketch<uint8_t>(nreg, b, a, QV) {}
     static constexpr size_t QV = 14u;
     template<typename Arg> NibbleSetS(const Arg &arg): SetSketch<uint8_t>(arg) {}
 };
 struct SmallNibbleSetS: public SetSketch<uint8_t> {
-    SmallNibbleSetS(size_t nreg, double b=4., double a=1e-6): SetSketch<uint8_t>(nreg, b, a, QV) {}
+    static constexpr long double DEFAULT_B = 4L;
+    static constexpr long double DEFAULT_A = 1e-6L;
     static constexpr size_t QV = 14u;
+    SmallNibbleSetS(size_t nreg, double b=DEFAULT_B, double a=DEFAULT_A): SetSketch<uint8_t>(nreg, b, a, QV) {}
     template<typename Arg> SmallNibbleSetS(const Arg &arg): SetSketch<uint8_t>(arg) {}
 };
 struct ByteSetS: public SetSketch<uint8_t, long double> {

--- a/src/sketch_core.cpp
+++ b/src/sketch_core.cpp
@@ -114,8 +114,7 @@ SketchingResult &sketch_core(SketchingResult &result, Dashing2Options &opts, con
             checked_fwrite(&k, sizeof(k), 1, ofp);
             checked_fwrite(&w, sizeof(w), 1, ofp);
         }
-        checked_fwrite(result.cardinalities_.data(), sizeof(double), result.cardinalities_.size(), ofp) != re
-            THROW_EXCEPTION(std::runtime_error("Failed to write lengths of sequences to disk.\n"));
+        checked_fwrite(result.cardinalities_.data(), sizeof(double), result.cardinalities_.size(), ofp);
         offset = 0;
         for(size_t i = 0; i < result.nperfile_.size(); ++i) {
             if(result.nperfile_[i]) {

--- a/src/sketch_core.cpp
+++ b/src/sketch_core.cpp
@@ -37,9 +37,9 @@ SketchingResult &sketch_core(SketchingResult &result, Dashing2Options &opts, con
         std::copy(res.nsamples_per_file().begin(), res.nsamples_per_file().end(), result.nperfile_.begin());
         std::FILE *of = bfopen(outfile.data(), "wb");
         uint64_t ns = result.names_.size();
-        std::fwrite(&ns, sizeof(ns), 1, of);
+        checked_fwrite(&ns, sizeof(ns), 1, of);
         ns = opts.sketchsize_;
-        std::fwrite(&ns, sizeof(ns), 1, of);
+        checked_fwrite(&ns, sizeof(ns), 1, of);
         std::fclose(of);
         result.signatures_.assign(outfile);
         result.signatures_.resize(res.registers().size());
@@ -108,18 +108,18 @@ SketchingResult &sketch_core(SketchingResult &result, Dashing2Options &opts, con
     if(opts.kmer_result_ == FULL_MMER_SEQUENCE) {
         if((ofp = bfopen(outfile.data(), "r+")) == nullptr) THROW_EXCEPTION(std::runtime_error("Failed to open output file for mmer sequence results."));
         size_t offset = result.names_.size();
-        std::fwrite(&offset, sizeof(offset), 1, ofp);
+        checked_fwrite(&offset, sizeof(offset), 1, ofp);
         {
             const uint32_t k = opts.k_, w = opts.w_;
-            std::fwrite(&k, sizeof(k), 1, ofp);
-            std::fwrite(&w, sizeof(w), 1, ofp);
+            checked_fwrite(&k, sizeof(k), 1, ofp);
+            checked_fwrite(&w, sizeof(w), 1, ofp);
         }
-        if(std::fwrite(result.cardinalities_.data(), sizeof(double), result.cardinalities_.size(), ofp) != result.cardinalities_.size())
+        checked_fwrite(result.cardinalities_.data(), sizeof(double), result.cardinalities_.size(), ofp) != re
             THROW_EXCEPTION(std::runtime_error("Failed to write lengths of sequences to disk.\n"));
         offset = 0;
         for(size_t i = 0; i < result.nperfile_.size(); ++i) {
             if(result.nperfile_[i]) {
-                std::fwrite(&result.signatures_.at(offset), sizeof(RegT), result.nperfile_[i], ofp);
+                checked_fwrite(&result.signatures_.at(offset), sizeof(RegT), result.nperfile_[i], ofp);
                 offset += result.nperfile_.at(i);
             }
         }
@@ -147,12 +147,12 @@ SketchingResult &sketch_core(SketchingResult &result, Dashing2Options &opts, con
         std::fputs("#Name\tCardinality\n", ofp);
         for(size_t i = 0; i < result.names_.size(); ++i) {
             const auto &n(result.names_[i]);
-            if(std::fwrite(n.data(), 1, n.size(), ofp) != n.size()) THROW_EXCEPTION(std::runtime_error("Failed to write names to file"));
+            checked_fwrite(n.data(), 1, n.size(), ofp);
             if(result.cardinalities_.size()) {
                 std::fprintf(ofp, tfmt<double>, result.cardinalities_[i]);
             }
             if(auto &kf = result.kmercountfiles_; !kf.empty())
-                std::fputc('\t', ofp), std::fwrite(kf[i].data(), 1, kf[i].size(), ofp);
+                std::fputc('\t', ofp), checked_fwrite(kf[i].data(), 1, kf[i].size(), ofp);
             std::fputc('\n', ofp);
         }
         std::fclose(ofp);
@@ -161,8 +161,7 @@ SketchingResult &sketch_core(SketchingResult &result, Dashing2Options &opts, con
         const size_t nb = result.kmercounts_.size() * sizeof(decltype(result.kmercounts_)::value_type);
         DBG_ONLY(std::fprintf(stderr, "Writing kmercounts of size %zu\n", result.kmercounts_.size());)
         if((ofp = bfopen((outfile + ".kmercounts.f64").data(), "wb"))) {
-            if(std::fwrite(result.kmercounts_.data(), nb, 1, ofp) != size_t(1))
-                std::fprintf(stderr, "Failed to write k-mer counts to disk properly, silent failing\n");
+            checked_fwrite(result.kmercounts_.data(), nb, 1, ofp);
             std::fclose(ofp);
         } else {
             DBG_ONLY(std::fprintf(stderr, "Failed to open file at %s to write k-mer counts, failing silently.\n", (outfile + ".kmercounts.f64").data());)

--- a/src/wsketch.cpp
+++ b/src/wsketch.cpp
@@ -258,8 +258,7 @@ void write_container(const T &vec, std::string path) {
     std::FILE *ifp = bfopen(path.data(), "wb");
     if(!ifp)
         THROW_EXCEPTION(std::runtime_error(std::string("Failed to open path '") + path + "' for reading"));
-    static constexpr size_t vnb = sizeof(std::decay_t<decltype(*vec.begin())>);
-    std::fwrite(vec.data(), vnb, nb, ifp);
+    checked_fwrite(vec.data(), sizeof(std::decay_t<decltype(*vec.begin())>), nb, ifp);
     std::fclose(ifp);
 }
 int wsketch_main(int argc, char **argv) {


### PR DESCRIPTION
Fix allocation bug in setsketch (aligned_alloc requires argument 2 be divisible by argument 1).

This also allows for --setsketch-ab/--fastcmp-nibbles/--fastcmp-bytes/--fastcmp-shorts to be used in `--parse-by-seq` mode.

This sacrifices the ability to tune the setsketch parameters to the data, but it can reduce peak memory requirements/total size available substantially.