### PR TITLE
D10

### DIFF
--- a/python/parse.py
+++ b/python/parse.py
@@ -5,6 +5,23 @@ from collections import namedtuple
 ParsedSignatureMatrix = namedtuple("ParsedSignatureMatrix", 'nseqs, cardinalities, signatures')
 ParsedKmerMatrix = namedtuple("ParsedKmerMatrix", 'k,w,canon,alphabet,sketchsize,seed,kmers')
 
+alphabet_dict = {0: 'DNA',
+ 1: 'PROTEIN',
+ 2: 'PROTEIN20',
+ 3: 'PROTEIN_3BIT',
+ 4: 'PROTEIN_14',
+ 5: 'PROTEIN_6',
+ 6: 'DNA2',
+ 7: 'DNAC',
+ 'DNA': 0,
+ 'PROTEIN': 1,
+ 'PROTEIN20': 2,
+ 'PROTEIN_3BIT': 3,
+ 'PROTEIN_14': 4,
+ 'PROTEIN_6': 5,
+ 'DNA2': 6,
+ 'DNAC': 7}
+
 
 def parse_knn(path, idsize=4, dstsize=4):
     '''
@@ -159,11 +176,13 @@ def parse_minimizer_sequence_set(path):
     import numpy as np
     dat = np.memmap(path, dtype=np.uint8)
     nseqs = int(dat[:8].view(np.uint64))
-    k, w = map(int, dat[8:16].view(np.uint32))
+    k, w, dt = map(int, dat[8:16].view(np.uint32))
+    alphabet = alphabet_dict[dt & 0xff]
+    canon = bool(dt & 256)
     cards = dat[16:16 + (8 * nseqs)].view(np.float64)
     indptr = np.cumsum(np.hstack([[0], cards]).astype(np.uint64))
     lo = dat[16 + (8 * nseqs):].view(np.uint64)
-    return {"nseqs": nseqs, "k": k, "w": w, "seqs": [lo[indptr[i]:indptr[i + 1]] for i in range(nseqs)]}
+    return {"canon": canon, "alphabet": alphabet, "nseqs": nseqs, "k": k, "w": w, "seqs": [lo[indptr[i]:indptr[i + 1]] for i in range(nseqs)]}
 
 
 __all__ = ["parse_knn", "parse_binary_signatures", "ParsedSignatureMatrix", "parse_binary_kmers", "ParsedKmerMatrix", "alphabetcvt", "pairwise_equality_compare", "parse_binary_clustering", "parse_binary_distmat", "parse_binary_rectmat",

--- a/python/parse.py
+++ b/python/parse.py
@@ -154,4 +154,17 @@ def parse_binary_contain(path):
     return {"nref": nref, "nqueries": nqueries, "coverage_matrix": coverage_fractions, "depth_matrix": meandepth}
 
 
-__all__ = ["parse_knn", "parse_binary_signatures", "ParsedSignatureMatrix", "parse_binary_kmers", "ParsedKmerMatrix", "alphabetcvt", "pairwise_equality_compare", "parse_binary_clustering", "parse_binary_distmat", "parse_binary_rectmat"]
+
+def parse_minimizer_sequence_set(path):
+    import numpy as np
+    dat = np.memmap(path, dtype=np.uint8)
+    nseqs = int(dat[:8].view(np.uint64))
+    k, w = map(int, dat[8:16].view(np.uint32))
+    cards = dat[16:16 + (8 * nseqs)].view(np.float64)
+    indptr = np.cumsum(np.hstack([[0], cards]).astype(np.uint64))
+    lo = dat[16 + (8 * nseqs):].view(np.uint64)
+    return {"nseqs": nseqs, "k": k, "w": w, "seqs": [lo[indptr[i]:indptr[i + 1]] for i in range(nseqs)]}
+
+
+__all__ = ["parse_knn", "parse_binary_signatures", "ParsedSignatureMatrix", "parse_binary_kmers", "ParsedKmerMatrix", "alphabetcvt", "pairwise_equality_compare", "parse_binary_clustering", "parse_binary_distmat", "parse_binary_rectmat",
+           "parse_minimizer_sequence_set"]

--- a/src/d2.cpp
+++ b/src/d2.cpp
@@ -136,8 +136,13 @@ int printmin_main(int argc, char **argv) {
     uint32_t dtype;
     checked_fread(&dtype, 1, sizeof(dtype), ifp);
     // uint32_t dtype = (uint32_t)opts.input_mode() | (int(opts.canonicalize()) << 8);
+#if 0
     const bool canon = (dtype >> 8) & 1;
-    const bns::RollingHashingType rht = dtype & 0xff;
+#endif
+    const bns::RollingHashingType rht = static_cast<bns::RollingHashingType>(dtype & 0xff);
+    if(rht != bns::InputType::DNA) {
+        THROW_EXCEPTION(std::runtime_error("Not yet implemented: minimizer sequence printing for non-DNA alphabets"));
+    }
     std::vector<uint32_t> lengths(nseqs);
     for(size_t i = 0; i < nseqs; ++i) {
         double v;

--- a/src/d2.cpp
+++ b/src/d2.cpp
@@ -133,6 +133,11 @@ int printmin_main(int argc, char **argv) {
     uint32_t k, w;
     checked_fread(&k, 1, sizeof(k), ifp);
     checked_fread(&w, 1, sizeof(k), ifp);
+    uint32_t dtype;
+    checked_fread(&dtype, 1, sizeof(dtype), ifp);
+    // uint32_t dtype = (uint32_t)opts.input_mode() | (int(opts.canonicalize()) << 8);
+    const bool canon = (dtype >> 8) & 1;
+    const bns::RollingHashingType rht = dtype & 0xff;
     std::vector<uint32_t> lengths(nseqs);
     for(size_t i = 0; i < nseqs; ++i) {
         double v;

--- a/src/enums.cpp
+++ b/src/enums.cpp
@@ -76,6 +76,11 @@ void checked_fwrite(std::FILE *const fp, const void *const ptr, const size_t nb)
     if(unlikely(lrc != static_cast<size_t>(nb)))
          throw std::runtime_error(std::string("[E:") + __PRETTY_FUNCTION__ + ':' + __FILE__ + std::to_string(__LINE__) + "] Failed to perform buffered write of " + std::to_string(static_cast<size_t>(nb)) + " bytes, instead writing " + std::to_string(lrc) + " bytes");
 }
+void checked_fread(std::FILE *const fp, void *const ptr, const size_t nb) {
+    unsigned long long lrc = std::fread(static_cast<void *>(ptr), 1, nb, fp);
+    if(unlikely(lrc != static_cast<size_t>(nb)))
+         throw std::runtime_error(std::string("[E:") + __PRETTY_FUNCTION__ + ':' + __FILE__ + std::to_string(__LINE__) + "] Failed to perform buffered read of " + std::to_string(static_cast<size_t>(nb)) + " bytes, instead reading " + std::to_string(lrc) + " bytes");
+}
 
 std::pair<std::FILE *, int> xopen(const std::string &path) {
     std::FILE *fp;

--- a/src/enums.h
+++ b/src/enums.h
@@ -111,6 +111,10 @@ void checked_fwrite(std::FILE *fp, const void *src, const size_t nb);
 inline void checked_fwrite(const void *ptr, const size_t itemsize, const size_t nitems, std::FILE *fp) {
     checked_fwrite(fp, ptr, itemsize * nitems);
 }
+void checked_fread(std::FILE *fp, void *src, const size_t nb);
+inline void checked_fread(void *ptr, const size_t itemsize, const size_t nitems, std::FILE *fp) {
+    checked_fread(fp, ptr, itemsize * nitems);
+}
 std::pair<std::FILE *, int> xopen(const std::string &path);
 
 extern uint64_t XORMASK;

--- a/src/options.h
+++ b/src/options.h
@@ -100,7 +100,7 @@ enum OptArg {
     LO_FLAG("mash-distance", OPTARG_MASHDIST, measure, POISSON_LLR)\
     LO_FLAG("distance", OPTARG_MASHDIST, measure, POISSON_LLR)\
     LO_FLAG("symmetric-containment", OPTARG_SYMCONTAIN, measure, SYMMETRIC_CONTAINMENT)\
-    LO_FLAG("containment", OPTARG_CONTAIN, measure, SYMMETRIC_CONTAINMENT)\
+    LO_FLAG("containment", OPTARG_CONTAIN, measure, Measure::CONTAINMENT)\
     LO_FLAG("poisson-distance", OPTARG_MASHDIST, measure, POISSON_LLR)\
     LO_FLAG("compute-edit-distance", OPTARG_MASHDIST, measure, M_EDIT_DISTANCE)\
     LO_FLAG("multiset", OPTARG_DUMMY, sketch_space, SPACE_MULTISET)\

--- a/src/sketch_core.cpp
+++ b/src/sketch_core.cpp
@@ -113,6 +113,8 @@ SketchingResult &sketch_core(SketchingResult &result, Dashing2Options &opts, con
             const uint32_t k = opts.k_, w = opts.w_;
             checked_fwrite(&k, sizeof(k), 1, ofp);
             checked_fwrite(&w, sizeof(w), 1, ofp);
+            uint32_t dtype = (uint32_t)opts.input_mode() | (int(opts.canonicalize()) << 8);
+            checked_fwrite(&dtype, sizeof(dtype), 1, ofp);
         }
         checked_fwrite(result.cardinalities_.data(), sizeof(double), result.cardinalities_.size(), ofp);
         offset = 0;


### PR DESCRIPTION
1. Containment fixes
    1.  --containment was setting distance to SYMMETRIC_CONTAINMENT instead of CONTAINMENT.
    2. Union/intersection cardinality estimation was wrong due to missing parenthesis. Only sketch-based methods are affected.
2. Minimizer sequence transduction
    1. Add in alphabet to serialized form of minimizer sequence transduction.
    2. Add `parse_minimizer_sequence_set` to Python parsing code for reading these databases.
    3. Added `printmin` subcommand, which formats minimizer sequence sets to human-readable (fasta or tabular).