### PR TITLE
Cleanup pt2

### DIFF
--- a/src/cmp_main.h
+++ b/src/cmp_main.h
@@ -64,7 +64,7 @@ struct Dashing2DistOptions: public Dashing2Options {
         Dashing2Options(opts), output_kind_(outres), output_format_(of), outfile_path_(outpath), exact_kmer_dist_(exact_kmer_dist), refine_exact_(refine_exact), nLSH(nlshsubs)
     {
         if(verbosity) {
-            std::fprintf(stderr, "[%s] output format should be %s based on start\n", __PRETTY_FUNCTION__, ::dashing2::to_string(output_format_).data());
+            std::fprintf(stderr, "[%s] output format is %s\n", __PRETTY_FUNCTION__, ::dashing2::to_string(output_format_).data());
         }
         set_sketch_compressed();
         if(nbytes_for_fastdists < 0) nbytes_for_fastdists = sizeof(RegT);

--- a/src/fastxsketch.cpp
+++ b/src/fastxsketch.cpp
@@ -226,6 +226,9 @@ FastxSketchingResult &fastx2sketch(FastxSketchingResult &ret, Dashing2Options &o
         const size_t offset = sizeof(nitems) * 2 + sizeof(double) * nitems;
         ::truncate(outpath.data(), offset);
         ret.signatures_.assign(outpath, offset);
+        if(verbosity >= DEBUG) {
+            std::fprintf(stderr, "Assigning vector of size %zu to mmap'd file of size %zu\n", ret.signatures_.size(), offset + ret.signatures_.size() * sizeof(RegT));
+        }
         if(opts.save_kmers_) {
             kmeroutpath = outpath + ".kmer64";
             kmernamesoutpath = kmeroutpath + ".names.txt";

--- a/src/sketch_core.cpp
+++ b/src/sketch_core.cpp
@@ -76,7 +76,7 @@ SketchingResult &sketch_core(SketchingResult &result, Dashing2Options &opts, con
                     DBG_ONLY(std::fprintf(stderr, "Cardinality %g found from path %s/%zu\n", res.card_, p.data(), i);)
                     //std::copy(sigs.begin(), sigs.end(), &result.signatures_[opts.sketchsize_* i]);
                 }
-                const auto total_n = std::accumulate(result.nperfile_.begin(), result.nperfile_.end(), size_t(0));
+                const size_t total_n = std::accumulate(result.nperfile_.begin(), result.nperfile_.end(), size_t(0));
                 size_t offset = 0;
                 result.signatures_.resize(total_n * opts.sketchsize_);
                 result.names_.resize(total_n);


### PR DESCRIPTION
Another bug fix: when using `-o` during sketching in separate sketch/cmp mode, we were erasing the previously existing sketches before.

This fixes that bug, so you can call sketch:

```
dashing2 sketch -o packed.sketch -F smallbac.list -p10
```

And compare:
```
dashing2 cmp --cmpout packed.dist --presketched packed.sketch -p10
```

We hadn't tested this code path.

We also add python code for creating this packed.sketch from individual sketch files in `python/parse.py` under `convert_sketches_to_packed_sketch`, and code for parsing individual sketch files as `parse_binary_sketch`.