### PR TITLE
Bug fixes, remove -flto in static builds + logging changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ OBJ0=$(patsubst %.o,%.0,$(OFS)) src/osfmt.o
 OBJV=$(patsubst %.o,%.vo,$(OFS)) src/osfmt.o
 OBJG=$(patsubst %.o,%.gobj,$(OFS)) src/osfmt.o
 OBJW=$(patsubst %.o,%.wo,$(OFS)) src/osfmt.o
+OBJNLTO=$(patsubst %.o,%.nlto,$(OFS)) src/osfmt.o
 
 all: dashing2 dashing2-64
 unit: readfx readbw readbed
@@ -98,6 +99,8 @@ dashing2-f64: $(OBJF64) libBigWig.a
 	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $(OBJF64) -o $@ $(LIB) $(EXTRA) libBigWig.a -DNDEBUG -flto  -DLSHIDTYPE="uint64_t"
 dashing2-ld64: $(OBJLD64) libBigWig.a
 	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $(OBJLD64) -o $@ $(LIB) $(EXTRA) libBigWig.a -DNDEBUG -flto  -DLSHIDTYPE="uint64_t"
+dashing2-nftmp: $(OBJNLTO) libBigWig.a $(wildcard src/*.h)
+	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $(OBJNLTO) -o $@ $(LIB) $(EXTRA) libBigWig.a -DNDEBUG
 read%: test/read%.o $(LIBOBJ)
 	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $< $(LIBOBJ) -o $@ $(LIB) $(EXTRA) libBigWig.a
 read%-ld: test/read%.ldo $(LDLIBOBJ)
@@ -116,7 +119,7 @@ read%-f: test/read%.fo $(FLIBOBJ)
 %.64o: %.c
 	$(CC) $(INC) $(OPTMV) $(WARNING) $(MACH) $< -c -o $@ $(EXTRA) -DNDEBUG -flto -O3 -DLSHIDTYPE="uint64_t" -std=c11
 %.0: %.cpp
-	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $< -c -o $@ $(EXTRA) -O0
+	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $< -c -o $@ $(EXTRA) -O0 -DNDEBUG
 %.0: %.c
 	$(CC) $(INC) $(OPTMV) $(WARNING) $(MACH) $< -c -o $@ $(EXTRA) -DNDEBUG -O0 -std=c11
 %.vo: %.cpp
@@ -149,6 +152,10 @@ read%-f: test/read%.fo $(FLIBOBJ)
 	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $< -c -o $@ $(EXTRA) -DSKETCH_FLOAT_TYPE="long double" -DNDEBUG -flto  -DLSHIDTYPE="uint64_t"
 %.f64o: %.cpp $(wildcard src/*.h)
 	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $< -c -o $@ $(EXTRA) -DSKETCH_FLOAT_TYPE="float" -DNDEBUG  -flto -DLSHIDTYPE="uint64_t"
+%.nlto: %.cpp
+	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $< -c -o $@ $(EXTRA) -DNDEBUG -O3
+%.nlto: %.c $(wildcard src/*.h)
+	$(CC) $(INC) $(OPT) $(WARNING) $(MACH) $< -c -o $@ $(EXTRA) -DNDEBUG -O3 -std=c11
 src/osfmt.o: fmt/src/os.cc
 	$(CXX) -I fmt/include $(OPT) $(WARNING) $< -c -o $@ $(EXTRA)
 
@@ -169,26 +176,26 @@ libgomp.a:
 dashing2_s128: $(D2SRC) $(wildcard src/*.h) libgomp.a $(BWF) fmt/src/os.cc
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mno-avx512dq -mno-avx512vl -mno-avx512f -mno-avx512bw -mno-avx -mno-avx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
     fmt/src/os.cc libgomp.a $(BWF) \
-		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
+		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz -DNDEBUG
 
 dashing2_savx: $(D2SRC) $(wildcard src/*.h) fmt/src/os.cc libgomp.a $(BWF)
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mno-avx512dq -mno-avx512vl -mno-avx512f -mno-avx512bw -mavx -mno-avx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
     fmt/src/os.cc libgomp.a $(BWF) \
-		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
+		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz -DNDEBUG
 
 dashing2_savx2: $(D2SRC) $(wildcard src/*.h) fmt/src/os.cc libgomp.a $(BWF)
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mno-avx512dq -mno-avx512vl -mno-avx512f -mno-avx512bw -mavx -mavx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
     fmt/src/os.cc libgomp.a $(BWF) \
-		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
+		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz -DNDEBUG
 
 dashing2_s512: $(D2SRC) $(wildcard src/*.h) fmt/src/os.cc libgomp.a $(BWF)
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mno-avx512dq -mno-avx512vl -mno-avx512bw -mavx512f -mavx -mavx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
     fmt/src/os.cc libgomp.a $(BWF) \
-		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
+		-DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz -DNDEBUG
 
 dashing2_s512bw: $(D2SRC) $(wildcard src/*.h) fmt/src/os.cc libgomp.a $(BWF)
 	$(CXX) $(CXXFLAGS) $(OPT) $(WARNING) $(MACH) $(INC) $(LIB) -mavx512dq -mavx512vl -mavx512bw -mavx512f -mavx -mavx2 -msse2 -msse4.1 -static-libstdc++ -static-libgcc -flto \
-    fmt/src/os.cc libgomp.a $(BWF) -DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz
+    fmt/src/os.cc libgomp.a $(BWF) -DNDEBUG $(D2SRC) -o $@ $(EXTRA) $(LIB) -ldl -lz -DNDEBUG
 
 dashing2_static: dashing2_s128 dashing2_savx dashing2_savx2 dashing2_s512 dashing2_s512bw
 static: dashing2_static

--- a/src/cmp_core.cpp
+++ b/src/cmp_core.cpp
@@ -427,15 +427,7 @@ case v: {\
     } else if(opts.kmer_result_ <= FULL_SETSKETCH) {
         const RegT *lhsrc = &result.signatures_[opts.sketchsize_ * i], *rhsrc = &result.signatures_[opts.sketchsize_ * j];
         if(opts.sspace_ == SPACE_SET && opts.truncation_method_ <= 0) {
-            auto gtlt = sketch::eq::count_gtlt(lhsrc, rhsrc, opts.sketchsize_);
-            if(verbosity >= Verbosity::DEBUG) {
-                auto getFive = [](auto src) {return std::accumulate(src, src + 5, std::string{}, [](auto x, auto y) {x += std::to_string(y); x += ','; return x;});};
-#if 0
-                auto lh_five = getFive(lhsrc);
-                auto rh_five = getFive(rhsrc);
-#endif
-                std::fprintf(stderr, "Computed gtlt for sketchsize=%d, and first entries = %s/%s\n", int(opts.sketchsize_), getFive(lhsrc).data(), getFive(rhsrc).data());
-            }
+            const auto gtlt = sketch::eq::count_gtlt(lhsrc, rhsrc, opts.sketchsize_);
             long double alpha, beta, eq, lhcard, ucard, rhcard;
             alpha = gtlt.first * invdenom;
             beta = gtlt.second * invdenom;

--- a/src/cmp_core.cpp
+++ b/src/cmp_core.cpp
@@ -327,7 +327,7 @@ LSHDistType compare(const Dashing2DistOptions &opts, const SketchingResult &resu
 #if COUNT_COMPARE_CALLS
     ++compare_count;
 #endif
-    if(verbosity >= 2) {
+    if(verbosity >= EXTREME) {
         std::fprintf(stderr, "About to compare sketches %zd and %zd. names size is %zu, signatures size is %zu. kmer counts %zu, and %zu kmers. Cardinalities %zu\n", i, j, result.names_.size(), result.signatures_.size(), result.kmercounts_.size(), result.kmers_.size(), result.cardinalities_.size());
     }
 #if 0
@@ -544,11 +544,11 @@ inline size_t densify(MHT *minhashes, uint64_t *const kmers, const size_t sketch
     for(size_t i = 0; i < sketchsize; ++i) {
         if(minhashes[i] != empty) continue;
         uint64_t j = i;
-        uint64_t rng = i;
+        uint64_t rng = (i + 1) * 0x501cdd81;
         while(minhashes[j] == empty) {
             static constexpr uint32_t PRIMEMOD = 4294967291u;
             auto a = (wy::wyhash64_stateless(&rng) % PRIMEMOD), b = (wy::wyhash64_stateless(&rng) % PRIMEMOD), c = (wy::wyhash64_stateless(&rng) % PRIMEMOD);
-            j = div.mod((((a * b) % PRIMEMOD + c) % PRIMEMOD));
+            j = div.mod(((a * b) % PRIMEMOD + c) % PRIMEMOD);
         }
         minhashes[i] = minhashes[j];
         if(kmers) kmers[i] = kmers[j];
@@ -638,7 +638,7 @@ void cmp_core(const Dashing2DistOptions &opts, SketchingResult &result) {
                                  kp ? &kp[opts.sketchsize_ * i]: kp,
                                  opts.sketchsize_, sd);
         }
-        if(totaldens > 0) std::fprintf(stderr, "Densified a total of %zu/%zu entries\n", totaldens, opts.sketchsize_ * n);
+        if((verbosity >= INFO) && (totaldens > 0)) std::fprintf(stderr, "Densified a total of %zu/%zu entries\n", totaldens, opts.sketchsize_ * n);
     }
     //std::fprintf(stderr, "Handled generating needed cardinalities\n");
     // Calculate cardinalities if they haven't been
@@ -662,6 +662,9 @@ void cmp_core(const Dashing2DistOptions &opts, SketchingResult &result) {
     make_compressed(cret, opts.truncation_method_, opts.fd_level_, result.signatures_, result.kmers_, opts.sspace_ == SPACE_EDIT_DISTANCE, opts.compressed_a_, opts.compressed_b_, opts.sketch_compressed_set);
     std::tie(opts.compressed_ptr_, opts.compressed_a_, opts.compressed_b_) = cret;
     if(opts.output_kind_ <= ASYMMETRIC_ALL_PAIRS || opts.output_kind_ == PANEL) {
+        if(verbosity >= Verbosity::DEBUG) {
+            std::fprintf(stderr, "before calling emit_rectangular, output format is %s\n", to_string(opts.output_format_).data());
+        }
         emit_rectangular(opts, result);
         return;
     }

--- a/src/cmp_main.cpp
+++ b/src/cmp_main.cpp
@@ -235,12 +235,12 @@ int cmp_main(int argc, char **argv) {
     // By default, use full hash values, but allow people to enable smaller
     OutputFormat of = OutputFormat::HUMAN_READABLE;
     if(verbosity >= Verbosity::DEBUG) {
-        std::fprintf(stderr, "output format should be %s based on start\n", to_string(of).data());
+        std::fprintf(stderr, "output format should be %s based on value at start\n", to_string(of).data());
     }
     validate_options(argv, std::vector<std::string>{{"presketched"}});
     CMP_OPTS(cmp_long_options);
     std::vector<std::string> paths;
-    if(verbosity >= INFO) {
+    if(verbosity >= Verbosity::INFO) {
         std::fprintf(stderr, "output format should be %s before parsing options \n", to_string(of).data());
     }
     for(;(c = getopt_long(argc, argv, "m:p:k:w:c:f:S:F:Q:o:L:vNs2BPWh?ZJGH", cmp_long_options, &option_index)) >= 0;) {switch(c) {
@@ -353,6 +353,9 @@ int cmp_main(int argc, char **argv) {
     } else {
         sketch_core(result, distopts, paths, outfile);
         result.nqueries(nq);
+    }
+    if(verbosity >= Verbosity::EXTREME) {
+        std::fprintf(stderr, "before cmp_core, output format is %s\n", to_string(distopts.output_format_).data());
     }
     cmp_core(distopts, result);
     return 0;

--- a/src/cmp_main.cpp
+++ b/src/cmp_main.cpp
@@ -356,6 +356,11 @@ int cmp_main(int argc, char **argv) {
     }
     if(verbosity >= Verbosity::EXTREME) {
         std::fprintf(stderr, "before cmp_core, output format is %s\n", to_string(distopts.output_format_).data());
+        for(uint32_t i = 0; i < result.total_seqs(); ++i) {
+            for(uint32_t j = 0; j < distopts.sketchsize_; ++j) {
+                std::fprintf(stderr, "Item %u has %g at idx %u\n", i, result.signatures_[i * distopts.sketchsize_ + j], j);
+            }
+        }
     }
     cmp_core(distopts, result);
     return 0;

--- a/src/emitrect.cpp
+++ b/src/emitrect.cpp
@@ -107,7 +107,7 @@ void batched_write(const float * &src, std::back_insert_iterator<fmt::memory_buf
 
 void emit_rectangular(const Dashing2DistOptions &opts, const SketchingResult &result) {
     if(verbosity >= Verbosity::DEBUG) {
-        std::fprintf(stderr, "output format should be %s based on start\n", to_string(opts.output_format_).data());
+        std::fprintf(stderr, "output format should be %s based on value at emit_rectangular start\n", to_string(opts.output_format_).data());
     }
     const size_t ns = result.names_.empty() ? result.nqueries(): result.names_.size();
     const std::string outp = opts.outfile_path_.empty() || opts.outfile_path_.front() == '-'
@@ -129,13 +129,9 @@ void emit_rectangular(const Dashing2DistOptions &opts, const SketchingResult &re
     const bool asym = opts.output_kind_ == ASYMMETRIC_ALL_PAIRS;
     std::deque<QTup> datq;
     std::mutex datq_lock;
-#ifndef NDEBUG
-    if(opts.output_format_ == MACHINE_READABLE) {
-        std::fprintf(stderr, "Emitting machine-readable: %s\n", to_string(opts.output_format_).data());
-    } else {
-        std::fprintf(stderr, "Emitting human-readable: %s\n", to_string(opts.output_format_).data());
+    if(verbosity >= Verbosity::DEBUG) {
+        std::fprintf(stderr, "Emitting %s: %s\n", opts.output_format_ == MACHINE_READABLE ? "machine readable": "human readable", to_string(opts.output_format_).data());
     }
-#endif
     // Emit Header
     if(opts.output_format_ == HUMAN_READABLE) {
         auto &of = ofopt.value();
@@ -205,6 +201,13 @@ void emit_rectangular(const Dashing2DistOptions &opts, const SketchingResult &re
     // and
     // Batched (batch_size > 1), which is more cache efficient by grouping comparisons
     // so that computations using the same data can share it
+    if(verbosity >= Verbosity::DEBUG) {
+        if(opts.output_format_ == MACHINE_READABLE) {
+            std::fprintf(stderr, "Before panel, emitting machine-readable: %s\n", to_string(opts.output_format_).data());
+        } else {
+            std::fprintf(stderr, "Before panel, emitting human-readable: %s\n", to_string(opts.output_format_).data());
+        }
+    }
     if(opts.output_kind_ == PANEL) {
         if(batch_size <= 1) {
             for(size_t i = 0; i < nf; ++i) {

--- a/src/enums.h
+++ b/src/enums.h
@@ -104,7 +104,8 @@ enum OutputFormat {
 enum Verbosity: int {
     STANDARD, // no extra logging
     INFO, // information, but not low-level information
-    DEBUG,
+    DEBUG, // low-level
+    EXTREME, // no reason you would ever do this!
 };
 
 std::string to_string(KmerSketchResultType t);

--- a/src/oph.h
+++ b/src/oph.h
@@ -33,7 +33,8 @@ struct CEIAdd {
 };
 using sketch::hash::CEIXOR;
 using sketch::hash::CEIMul;
-#if USE_SIMPLE_REVHASH
+#if 0
+// USE_SIMPLE_REVHASH
 using BHasher = sketch::hash::CEIFused<CEIXOR<0x533f8c2151b20f97>, CEIMul<0x9a98567ed20c127d>, CEIXOR<0x691a9d706391077a>>;
 #else
 using BHasher = sketch::hash::WangHash;
@@ -165,6 +166,7 @@ public:
             idx = idx & mask_;
         else
             idx -= m_ * div_.div(idx);
+        std::fprintf(stderr, "Pos: %zu. . Found pos: %zu. hash value: %zu. finalized-hash value %zu.\n", shasher_(id) % mask_, idx, id, shasher_(id));
         assert(idx < size());
         auto &cref = counts_[idx];
         auto &rref = registers_[idx];


### PR DESCRIPTION
Fixed a major bug parsing in signatures from files, affecting every build for 7 months.

-flto was causing an error in some builds to emit binary when text should have been emitted.

Hide verbose logging behind EXTREME log level.

Also modify random seed in densification code, which should result in better-distributed densified sketching.