### PR TITLE
Reduce memory usage in --parse-by-seq

### DIFF
--- a/src/fastxsketch.h
+++ b/src/fastxsketch.h
@@ -3,6 +3,7 @@
 #define DASHING2_FASTX_SKETCH_H__
 #include "d2.h"
 #include "mmvec.h"
+#include "tmpseqs.h"
 #include <variant>
 
 namespace dashing2 {
@@ -13,11 +14,16 @@ static inline std::string to_string(const T *ptr) {
     oss << static_cast<const void *>(ptr);
     return oss.str();
 }
+
+#ifndef SEQS_IN_MEM
+#define SEQS_IN_MEM 0
+#endif
+
 struct SketchingResult {
     SketchingResult() {}
     SketchingResult(SketchingResult &&o) = default;
     SketchingResult(const SketchingResult &o) = delete;
-    SketchingResult(SketchingResult &o) = default;
+    SketchingResult(SketchingResult &o) = delete;
     SketchingResult &operator=(SketchingResult &&o) = default;
     SketchingResult &operator=(const SketchingResult &o) = delete;
 
@@ -29,7 +35,11 @@ struct SketchingResult {
     std::vector<uint32_t> nperfile_; // This is either empty (in which case each filename/row has its own sketch)
                                      // Or, this contains a list indicating the number of sketches created for each file/line
     std::vector<double> cardinalities_;
+#if SEQS_IN_MEM
     std::vector<std::string> sequences_;
+#else
+    tmpseq::Seqs sequences_;
+#endif
     // This is only filled if sspace is SPACE_EDIT_DISTANCE and
     // we are using LSH only for pre-filtering but performing exact distance calculations via edit distance
     mm::vector<RegT> signatures_;

--- a/src/sketch_core.cpp
+++ b/src/sketch_core.cpp
@@ -1,4 +1,5 @@
 #include "sketch_core.h"
+#include "cmp_main.h"
 #include <cinttypes>
 
 namespace dashing2 {
@@ -10,7 +11,7 @@ INLINE size_t nbytes_from_line(const std::string &line) {
     return ret;
 }
 
-SketchingResult &sketch_core(SketchingResult &result, Dashing2Options &opts, const std::vector<std::string> &paths, std::string &outfile) {
+SketchingResult &sketch_core(SketchingResult &result, Dashing2DistOptions &opts, const std::vector<std::string> &paths, std::string &outfile) {
     if(opts.kmer_result() == FULL_MMER_SEQUENCE && outfile.empty()) {
         THROW_EXCEPTION(std::runtime_error("outfile must be specified for --seq mode."));
     }

--- a/src/tmpseqs.h
+++ b/src/tmpseqs.h
@@ -1,0 +1,88 @@
+#ifndef TEMPSEQS_H__
+#define TEMPSEQS_H__
+#include <cstdio>
+#include <stdexcept>
+#include <filesystem>
+
+namespace tmpseq {
+
+struct FileDeleter {
+    void operator()(std::FILE* const ptr) const noexcept {
+        if(ptr) {
+            std::fclose(ptr);
+        }
+    }
+};
+
+class Seqs {
+    std::string path_;
+    std::vector<int64_t> offsets_;
+    std::unique_ptr<std::FILE, FileDeleter> file_;
+
+    static std::string make_path(int64_t seed = 0) {
+        std::filesystem::path base = std::filesystem::temp_directory_path();
+        std::string randstr;
+        for(int i = 0; i < 10; ++i) {
+            randstr += (static_cast<char>(seed % 26) + 'a');
+            seed += 0x33b74ea7d2a06fd7;
+            seed *= 0x7262c70021180663;
+            seed ^= (seed >> 16);
+        }
+        base /= randstr;
+        return static_cast<std::string>(base);
+    }
+    static std::string make_new_file(int64_t seed=0) {
+        std::string ret;
+        do {
+            ret = make_path(seed++);
+        } while(std::filesystem::exists(ret));
+        return ret;
+    }
+public:
+    Seqs(): path_(make_new_file()), offsets_{0}, file_{std::fopen(path_.data(), "wb")} {}
+    Seqs(Seqs&& o) = default;
+    Seqs& operator=(Seqs&& o) = default;
+    Seqs(Seqs& o) = delete;
+    int64_t add_sequence(std::string_view seq) {
+        const int64_t ret = offsets_.back();
+        const int64_t seq_len = seq.size();
+        const int64_t written = std::fwrite(seq.data(), 1, seq_len, file_.get());
+        if(written != seq_len) {
+            throw std::runtime_error(std::string("ERROR: Failed to append sequence of size ") + std::to_string(seq.size()) + " to temporary file. Out of disk space?");
+        }
+        offsets_.push_back(ret + seq.size());
+        std::fflush(file_.get());
+        return ret;
+    }
+    void emplace_back(const char* ptr, size_t n) {
+        add_sequence(std::string_view(ptr, n));
+    }
+    void push_back(std::string_view seq) {
+        add_sequence(seq);
+    }
+    std::string operator[](const int64_t idx) const {
+        thread_local std::unique_ptr<std::FILE, FileDeleter> reader;
+        if(!reader) {
+            std::FILE *fp = std::fopen(path_.data(), "rb");
+            if(fp == nullptr) throw std::runtime_error(std::string("Failed to open file at ") + path_ + " for reading.");
+            reader.reset(fp);
+        }
+        const int64_t offset = offsets_[idx];
+        const int64_t end = offsets_[idx + 1];
+        std::fseek(reader.get(), offset, SEEK_SET);
+        const int64_t ret_size = end - offset;
+        std::string ret(ret_size, '\0');
+        const int64_t num_read = std::fread(ret.data(), 1, ret.size(), reader.get());
+        if(num_read != ret_size) {
+            throw std::runtime_error(std::string("ERROR: Failed to read sequence ") + std::to_string(idx) + '/' + std::to_string(size()) + " total. Read " + std::to_string(num_read) + " and expected " + std::to_string(ret.size()));
+        }
+        return ret;
+    }
+    int64_t size() const noexcept {
+        return (offsets_.size()) - 1;
+    }
+};
+
+}
+
+#endif


### PR DESCRIPTION
1. Spill to disk sequences if necessary downstream; otherwise, remove them from memory when not needed.
2. Add --seqs-in-ram option to do this in memory to trade RAM for time.
3. Add to documentation.