### PR TITLE
--parse-by-seq bug fix + orderminhash bug fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,11 @@ OPT+= -O3 \
     -fopenmp -pipe $(CACHE_SIZE_FLAG)
 
 OPTMV:=$(OPT)
-OPT+= -std=c++20
+CXXSTD?=-std=c++20
+OPT+= $(CXXSTD)
 WARNING+=-Wall -Wextra -Wno-unused-function -Wno-char-subscripts -pedantic -Wno-array-bounds # -Wno-shift-count-overflow
 EXTRA+=-DNOCURL -DDASHING2_VERSION=\"$(GIT_VERSION)\" -DFMT_HEADER_ONLY
-CXXFLAGS+= -std=c++20
+CXXFLAGS+= $(CXXSTD)
 CFLAGS+= -std=c11
 
 D2SRC=$(wildcard src/*.cpp)
@@ -91,7 +92,7 @@ dashing2-v: $(OBJV) libBigWig.a $(wildcard src/*.h)
 dashing2-d0: $(OBJDBG) libBigWig.a
 	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $(OBJDBG) -o $@ $(LIB) $(EXTRA) libBigWig.a -O0
 dashing2-add: $(OBJADD) libBigWig.a
-	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $(OBJADD) -o $@ $(LIB) $(EXTRA) libBigWig.a -fsanitize=address
+	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $(OBJADD) -o $@ $(LIB) $(EXTRA) libBigWig.a -fsanitize=address -O1
 dashing2-g: $(OBJG) libBigWig.a
 	$(CXX) $(INC) $(OPT) $(WARNING) $(MACH) $(OBJG) -o $@ $(LIB) $(EXTRA) libBigWig.a -fno-lto -pg
 dashing2-ld: $(OBJLD) libBigWig.a

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CC?=gcc
 
 CACHE_SIZE?=4194304
 CACHE_SIZE_FLAG:=-DD2_CACHE_SIZE=${CACHE_SIZE}
-GIT_VERSION?=$(shell git describe --abbrev=4 --always)
+GIT_VERSION?=v2.1.19
 
 
 # If on M1, use -target arm64-apple-macos11 -mmacosx-version-min=11.0

--- a/README.md
+++ b/README.md
@@ -278,9 +278,8 @@ Dashing2 has not been tested on Windows, and we do not support it.
 
 Alternatively, you can build from source with  `git clone --recursive https://github.com/dnbaker/dashing2 && make -j4`.
 
-Dashing2 is written in C++17, and therefore needs a relatively recent compiler, but the binary will be smaller than the statically-linked options provided
+Dashing2 now requires C++20, and therefore needs a relatively recent compiler, but the binary will be smaller than the statically-linked options provided
 and the code may be more directly tailored to your architecture.
-
 
 ## Versions + Configuration
 

--- a/src/cmp_core.cpp
+++ b/src/cmp_core.cpp
@@ -430,7 +430,7 @@ case v: {\
             }
         }
     } else if((opts.sspace_ == SPACE_EDIT_DISTANCE && opts.exact_kmer_dist_) || opts.measure_ == M_EDIT_DISTANCE) {
-        assert(result.sequences_.size() > std::max(i, j) || !std::fprintf(stderr, "Expected sequences to be non-null for exact edit distance calculation (%zu vs %zu/%zu)\n", result.sequences_.size(), i, j));
+        assert(size_t(result.sequences_.size()) > std::max(i, j) || !std::fprintf(stderr, "Expected sequences to be non-null for exact edit distance calculation (%zd vs %zu/%zu)\n", size_t(result.sequences_.size()), size_t(i), size_t(j)));
         auto lhs = result.sequences_[i];
         auto rhs = result.sequences_[j];
         if(verbosity >= DEBUG) {
@@ -590,7 +590,7 @@ inline size_t densify(std::span<MHT> minhashes, uint64_t *const kmers, const sch
             std::fprintf(stderr, "AFTER Sketch %zu is %g\n", i, double(minhashes[i]));
         }
     }
-    assert(std::find(minhashes, minhashes + sketchsize, empty) == minhashes + sketchsize);
+    assert(std::find(minhashes.begin(), minhashes.end(), empty) == minhashes.end());
     return ne;
 }
 
@@ -682,7 +682,7 @@ void cmp_core(const Dashing2DistOptions &opts, SketchingResult &result) {
                 }
             }
         };
-        if(verbosity >= DEBUG) {
+        if(verbosity >= EXTREME) {
             allpairdists("before");
         }
 #ifdef _OPENMP
@@ -693,7 +693,7 @@ void cmp_core(const Dashing2DistOptions &opts, SketchingResult &result) {
                                  kp ? &kp[opts.sketchsize_ * i]: kp,
                                  sd);
         }
-        if(verbosity >= DEBUG) {
+        if(verbosity >= EXTREME) {
             std::fprintf(stderr, "Densified.\n");
         }
         if((verbosity >= INFO) && (totaldens > 0)) std::fprintf(stderr, "Densified a total of %zu/%zu entries\n", totaldens, opts.sketchsize_ * n);

--- a/src/cmp_main.cpp
+++ b/src/cmp_main.cpp
@@ -83,7 +83,7 @@ void load_results(Dashing2DistOptions &opts, SketchingResult &result, const std:
             for(size_t i = 0; i < num_entities; ++i)
                 result.names_[i] = std::to_string(i);
         }
-        assert(result.cardinalities_.empty() || result.cardinalities_.size() == num_entities || !std::fprintf(stderr, "card size: %zu. Number expected: %zu\n", result.cardinalities_.size(), num_entities));
+        assert(result.cardinalities_.empty() || result.cardinalities_.size() == num_entities || !std::fprintf(stderr, "card size: %zu. Number expected: %zu\n", result.cardinalities_.size(), size_t(num_entities)));
         result.cardinalities_.resize(num_entities);
         // num_entities * sizeof(double) for the cardinalitiy
         if(std::fread(result.cardinalities_.data(), sizeof(double), result.cardinalities_.size(), fp) != result.cardinalities_.size())

--- a/src/fastxsketchbyseq.cpp
+++ b/src/fastxsketchbyseq.cpp
@@ -224,11 +224,9 @@ FastxSketchingResult &fastx2sketch_byseq(FastxSketchingResult &ret, Dashing2Dist
     }
     DBG_ONLY(std::fprintf(stderr, "save ids: %d, save counts %d\n", opts.save_kmers_, opts.save_kmercounts_););
     size_t lastindex = 0;
-    const bool need_to_keep_sequences = true;
-    /*
+    const bool need_to_keep_sequences =
                 (opts.measure_ == M_EDIT_DISTANCE || (opts.sspace_ == SPACE_EDIT_DISTANCE && opts.exact_kmer_dist_))
                                          || (opts.output_kind_ == DEDUP);
-    */
     if(verbosity >= DEBUG) {
         std::fprintf(stderr, "%s to keep sequences\n", need_to_keep_sequences ? "Need": "Do not need");
     }
@@ -273,11 +271,9 @@ void resize_fill(Dashing2DistOptions &opts, FastxSketchingResult &ret, size_t ne
     if(verbosity >= DEBUG) {
         std::fprintf(stderr, "Calling resize_fill with newsz = %zu\n", newsz);
     }
-    const bool need_to_keep_sequences = true;
-    /*
+    const bool need_to_keep_sequences =
             (opts.measure_ == M_EDIT_DISTANCE || (opts.sspace_ == SPACE_EDIT_DISTANCE && opts.exact_kmer_dist_))
                                          || (opts.output_kind_ == DEDUP);
-    */
     const size_t oldsz = ret.names_.size();
     newsz = oldsz + newsz;
     const int sigshift = opts.sigshift();

--- a/src/index_build.cpp
+++ b/src/index_build.cpp
@@ -28,9 +28,7 @@ void update(pqueue &x, flat_hash_set<LSHIDType> &xset, const PairT &item, const 
         xset.insert(id);
         x.push(item);
         return;
-        //assert(*std::min_element(x.begin(), x.end()) == x.front());
     }
-    //DBG_ONLY(std::fprintf(stderr, "Updating item %g/%u\n", item.first, item.second);)
     if(item.first <= x.top().first) {
         DBG_ONLY(std::fprintf(stderr, "New top before update: %g/Size %zu, with new item %g/%u added\n", x.front().first, x.size(), item.first, item.second);)
         std::lock_guard<std::mutex> lock(mut);
@@ -133,6 +131,9 @@ std::vector<pqueue> build_index(SetSketchIndex<LSHIDType, LSHIDType> &idx, const
             const auto cd(-LSHDistType(counts[j]));
             update(neighbor_lists[oid], neighbor_sets[oid], PairT{cd, id}, topk, ntoquery, mutexes[oid]);
             update(neighbor_lists[id], neighbor_sets[id], PairT{cd, oid}, topk, ntoquery, mutexes[id]);
+        }
+        if(verbosity >= DEBUG) {
+            std::fprintf(stderr, "Processed candidates for %zu/%zu\n", id, ns);
         }
     }
     if(verbosity >= DEBUG) {

--- a/src/oph.h
+++ b/src/oph.h
@@ -48,7 +48,7 @@ struct BHasher {
         return Hasher(SimpleHasher(x));
     }
     uint64_t inverse(uint64_t x) const noexcept {
-        return Hasher.inverse(SimpleHasher.inverse(x));
+        return SimpleHasher.inverse(Hasher.inverse(x));
     }
 };
 #endif

--- a/src/options.h
+++ b/src/options.h
@@ -280,6 +280,7 @@ const std::vector<std::string> VALID_LONG_OPTION_STRINGS {{
     "union-size",
     "verbose",
     "window-size",
+    "seqs-in-ram",
 }};
 
 // This function takes a vector of additional strings,

--- a/src/sketch_core.cpp
+++ b/src/sketch_core.cpp
@@ -26,7 +26,7 @@ SketchingResult &sketch_core(SketchingResult &result, Dashing2DistOptions &opts,
                 THROW_EXCEPTION(std::runtime_error("parse-by-seq currently only handles one file at a time. To process multiple files, simply concatenate them into one file, and run dashing2 on that."));
             }
             KSeqHolder kseqs(std::max(opts.nthreads(), 1u));
-            fastx2sketch_byseq(result, opts, paths.front(), kseqs.kseqs_, outfile, true);
+            fastx2sketch_byseq(result, opts, paths.front(), kseqs.kseqs_, outfile, true, 512);
         } else {
             fastx2sketch(result, opts, paths, outfile);
         }


### PR DESCRIPTION
1. Fix the --parse-by-seq code.
2. OrderMinHash bug fix from updating to sketch v0.19.1
3. Throw an error on empty sequences.
4. Improved handling of ram or memory sequences.

Since --parse-by-seq only needs sequences for edit distance calculation, we can free memory if running in --seqs-in-ram mode. Saves the trouble of caching the parsed sequences to disk, but requires more memory.

Lifetime management needed a bit of extra work, but it seems to be stable for both cases.